### PR TITLE
Updated types for ForceFn for react-force-graph-2d

### DIFF
--- a/src/packages/react-force-graph-2d/index.d.ts
+++ b/src/packages/react-force-graph-2d/index.d.ts
@@ -33,7 +33,7 @@ type DagMode = 'td' | 'bu' | 'lr' | 'rl' | 'radialout' | 'radialin';
 
 interface ForceFn {
   (alpha: number): void;
-  initialize?: (nodes: NodeObject[]) => void;
+  initialize?: (nodes: NodeObject[], ...args: any[]) => void;
   [key: string]: any;
 }
 


### PR DESCRIPTION
Updated the types for ForceFn for the react-force-graph-2d, as was already done with the react-force-graph-3d