### PR TITLE
fix: exports was missing types field

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "exports": {
     "umd": "./dist/react-force-graph.min.js",
     "default": "./dist/react-force-graph.mjs",
-    "types": "./dist/react-force-graph-2d.d.ts"
+    "types": "./dist/react-force-graph.d.ts"
   },
   "sideEffects": false,
   "repository": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
   "types": "dist/react-force-graph.d.ts",
   "exports": {
     "umd": "./dist/react-force-graph.min.js",
-    "default": "./dist/react-force-graph.mjs"
+    "default": "./dist/react-force-graph.mjs",
+    "types": "./dist/react-force-graph-2d.d.ts"
   },
   "sideEffects": false,
   "repository": {

--- a/package.json
+++ b/package.json
@@ -9,9 +9,9 @@
   "module": "dist/react-force-graph.mjs",
   "types": "dist/react-force-graph.d.ts",
   "exports": {
+    "types": "./dist/react-force-graph.d.ts",
     "umd": "./dist/react-force-graph.min.js",
-    "default": "./dist/react-force-graph.mjs",
-    "types": "./dist/react-force-graph.d.ts"
+    "default": "./dist/react-force-graph.mjs"
   },
   "sideEffects": false,
   "repository": {

--- a/src/packages/react-force-graph-2d/package.json
+++ b/src/packages/react-force-graph-2d/package.json
@@ -9,9 +9,9 @@
   "module": "dist/react-force-graph-2d.mjs",
   "types": "dist/react-force-graph-2d.d.ts",
   "exports": {
+    "types": "./dist/react-force-graph-2d.d.ts",
     "umd": "./dist/react-force-graph-2d.min.js",
-    "default": "./dist/react-force-graph-2d.mjs",
-    "types": "./dist/react-force-graph-2d.d.ts"
+    "default": "./dist/react-force-graph-2d.mjs"
   },
   "sideEffects": false,
   "repository": {

--- a/src/packages/react-force-graph-2d/package.json
+++ b/src/packages/react-force-graph-2d/package.json
@@ -10,7 +10,8 @@
   "types": "dist/react-force-graph-2d.d.ts",
   "exports": {
     "umd": "./dist/react-force-graph-2d.min.js",
-    "default": "./dist/react-force-graph-2d.mjs"
+    "default": "./dist/react-force-graph-2d.mjs",
+    "types": "./dist/react-force-graph-2d.d.ts"
   },
   "sideEffects": false,
   "repository": {

--- a/src/packages/react-force-graph-3d/package.json
+++ b/src/packages/react-force-graph-3d/package.json
@@ -9,9 +9,9 @@
   "module": "dist/react-force-graph-3d.mjs",
   "types": "dist/react-force-graph-3d.d.ts",
   "exports": {
+    "types": "./dist/react-force-graph-3d.d.ts",
     "umd": "./dist/react-force-graph-3d.min.js",
-    "default": "./dist/react-force-graph-3d.mjs",
-    "types": "./dist/react-force-graph-3d.d.ts"
+    "default": "./dist/react-force-graph-3d.mjs"
   },
   "sideEffects": false,
   "repository": {

--- a/src/packages/react-force-graph-3d/package.json
+++ b/src/packages/react-force-graph-3d/package.json
@@ -10,7 +10,8 @@
   "types": "dist/react-force-graph-3d.d.ts",
   "exports": {
     "umd": "./dist/react-force-graph-3d.min.js",
-    "default": "./dist/react-force-graph-3d.mjs"
+    "default": "./dist/react-force-graph-3d.mjs",
+    "types": "./dist/react-force-graph-3d.d.ts"
   },
   "sideEffects": false,
   "repository": {

--- a/src/packages/react-force-graph-ar/package.json
+++ b/src/packages/react-force-graph-ar/package.json
@@ -9,9 +9,9 @@
   "module": "dist/react-force-graph-ar.mjs",
   "types": "dist/react-force-graph-ar.d.ts",
   "exports": {
+    "types": "./dist/react-force-graph-ar.d.ts",
     "umd": "./dist/react-force-graph-ar.min.js",
-    "default": "./dist/react-force-graph-ar.mjs",
-    "types": "./dist/react-force-graph-ar.d.ts"
+    "default": "./dist/react-force-graph-ar.mjs"
   },
   "sideEffects": false,
   "repository": {

--- a/src/packages/react-force-graph-ar/package.json
+++ b/src/packages/react-force-graph-ar/package.json
@@ -10,7 +10,8 @@
   "types": "dist/react-force-graph-ar.d.ts",
   "exports": {
     "umd": "./dist/react-force-graph-ar.min.js",
-    "default": "./dist/react-force-graph-ar.mjs"
+    "default": "./dist/react-force-graph-ar.mjs",
+    "types": "./dist/react-force-graph-ar.d.ts"
   },
   "sideEffects": false,
   "repository": {

--- a/src/packages/react-force-graph-vr/package.json
+++ b/src/packages/react-force-graph-vr/package.json
@@ -9,9 +9,9 @@
   "module": "dist/react-force-graph-vr.mjs",
   "types": "dist/react-force-graph-vr.d.ts",
   "exports": {
+    "types": "./dist/react-force-graph-vr.d.ts",
     "umd": "./dist/react-force-graph-vr.min.js",
-    "default": "./dist/react-force-graph-vr.mjs",
-    "types": "./dist/react-force-graph-vr.d.ts"
+    "default": "./dist/react-force-graph-vr.mjs"
   },
   "sideEffects": false,
   "repository": {

--- a/src/packages/react-force-graph-vr/package.json
+++ b/src/packages/react-force-graph-vr/package.json
@@ -10,7 +10,8 @@
   "types": "dist/react-force-graph-vr.d.ts",
   "exports": {
     "umd": "./dist/react-force-graph-vr.min.js",
-    "default": "./dist/react-force-graph-vr.mjs"
+    "default": "./dist/react-force-graph-vr.mjs",
+    "types": "./dist/react-force-graph-vr.d.ts"
   },
   "sideEffects": false,
   "repository": {


### PR DESCRIPTION
Currently the library specifies the exports field in the package.json, but does not specify a type variant for the expert. This makes the library incompatible with Typescript 5's moduleResolution: "bundler" flag.

Reference:
https://www.typescriptlang.org/docs/handbook/esm-node.html#packagejson-exports-imports-and-self-referencing