### PR TITLE
Make graph data generic

### DIFF
--- a/src/packages/react-force-graph-2d/index.d.ts
+++ b/src/packages/react-force-graph-2d/index.d.ts
@@ -16,14 +16,14 @@ export type NodeObject = {
   fy?: number;
 };
 
-type NodeObjectIntersection<NodeType> = NodeType & NodeObject;
+type NodeObjectIntersection<NodeType> = NodeType & NodeObject & { [others: string]: any; };
 
 export type LinkObject<NodeType = {}> = {
   source?: string | number | NodeObjectIntersection<NodeType>;
   target?: string | number | NodeObjectIntersection<NodeType>;
 };
 
-type LinkObjectIntersection<NodeType, LinkType> = LinkType & LinkObject<NodeType>;
+type LinkObjectIntersection<NodeType, LinkType> = LinkType & LinkObject<NodeType> & { [others: string]: any; };
 
 type Accessor<In, Out> = Out | string | ((obj: In) => Out);
 

--- a/src/packages/react-force-graph-2d/index.d.ts
+++ b/src/packages/react-force-graph-2d/index.d.ts
@@ -1,9 +1,9 @@
 import * as React from 'react';
 import { ForceGraphInstance as ForceGraphKapsuleInstance } from 'force-graph';
 
-export interface GraphData<NodeType extends NodeObject, LinkType extends LinkObject<NodeType>> {
-  nodes: NodeType[];
-  links: LinkType[];
+export interface GraphData<NodeType, LinkType> {
+  nodes: NodeObjectIntersection<NodeType>[];
+  links: LinkObjectIntersection<NodeType, LinkType>[];
 }
 
 export type NodeObject = {
@@ -16,10 +16,14 @@ export type NodeObject = {
   fy?: number;
 };
 
-export type LinkObject<NodeType extends NodeObject> = {
-  source?: string | number | NodeType;
-  target?: string | number | NodeType;
+type NodeObjectIntersection<NodeType> = NodeType & NodeObject;
+
+export type LinkObject<NodeType> = {
+  source?: string | number | NodeObjectIntersection<NodeType>;
+  target?: string | number | NodeObjectIntersection<NodeType>;
 };
+
+type LinkObjectIntersection<NodeType, LinkType> = LinkType & LinkObject<NodeType>;
 
 type Accessor<In, Out> = Out | string | ((obj: In) => Out);
 
@@ -29,18 +33,18 @@ type CanvasPointerAreaPaintFn<T> = (obj: T, paintColor: string, canvasContext: C
 
 type DagMode = 'td' | 'bu' | 'lr' | 'rl' | 'radialout' | 'radialin';
 
-interface ForceFn<NodeType extends NodeObject> {
+interface ForceFn<NodeType> {
   (alpha: number): void;
-  initialize?: (nodes: NodeType[], ...args: any[]) => void;
+  initialize?: (nodes: NodeObjectIntersection<NodeType>[], ...args: any[]) => void;
   [key: string]: any;
 }
 
 export interface ForceGraphProps<
-  NodeType extends NodeObject,
-  LinkType extends LinkObject<NodeType>
+  NodeType,
+  LinkType
 > {
   // Data input
-  graphData?: GraphData<NodeType, LinkType>;
+  graphData?: GraphData<NodeObjectIntersection<NodeType>, LinkObjectIntersection<NodeType, LinkType>>;
   nodeId?: string;
   linkSource?: string;
   linkTarget?: string;
@@ -52,33 +56,33 @@ export interface ForceGraphProps<
 
   // Node styling
   nodeRelSize?: number;
-  nodeVal?: Accessor<NodeType, number>;
-  nodeLabel?: Accessor<NodeType, string>;
-  nodeVisibility?: Accessor<NodeType, boolean>;
-  nodeColor?: Accessor<NodeType, string>;
-  nodeAutoColorBy?: Accessor<NodeType, string | null>;
-  nodeCanvasObjectMode?: string | ((obj: NodeType) => CanvasCustomRenderMode | any);
-  nodeCanvasObject?: CanvasCustomRenderFn<NodeType>;
-  nodePointerAreaPaint?: CanvasPointerAreaPaintFn<NodeType>;
+  nodeVal?: Accessor<NodeObjectIntersection<NodeType>, number>;
+  nodeLabel?: Accessor<NodeObjectIntersection<NodeType>, string>;
+  nodeVisibility?: Accessor<NodeObjectIntersection<NodeType>, boolean>;
+  nodeColor?: Accessor<NodeObjectIntersection<NodeType>, string>;
+  nodeAutoColorBy?: Accessor<NodeObjectIntersection<NodeType>, string | null>;
+  nodeCanvasObjectMode?: string | ((obj: NodeObjectIntersection<NodeType>) => CanvasCustomRenderMode | any);
+  nodeCanvasObject?: CanvasCustomRenderFn<NodeObjectIntersection<NodeType>>;
+  nodePointerAreaPaint?: CanvasPointerAreaPaintFn<NodeObjectIntersection<NodeType>>;
 
   // Link styling
-  linkLabel?: Accessor<LinkType, string>;
-  linkVisibility?: Accessor<LinkType, boolean>;
-  linkColor?: Accessor<LinkType, string>;
-  linkAutoColorBy?: Accessor<LinkType, string | null>;
-  linkLineDash?: Accessor<LinkType, number[] | null>;
-  linkWidth?: Accessor<LinkType, number>;
-  linkCurvature?: Accessor<LinkType, number>;
-  linkCanvasObject?: CanvasCustomRenderFn<LinkType>;
-  linkCanvasObjectMode?: string | ((obj: LinkType) => CanvasCustomRenderMode | any);
-  linkDirectionalArrowLength?: Accessor<LinkType, number>;
-  linkDirectionalArrowColor?: Accessor<LinkType, string>;
-  linkDirectionalArrowRelPos?: Accessor<LinkType, number>;
-  linkDirectionalParticles?: Accessor<LinkType, number>;
-  linkDirectionalParticleSpeed?: Accessor<LinkType, number>;
-  linkDirectionalParticleWidth?: Accessor<LinkType, number>;
-  linkDirectionalParticleColor?: Accessor<LinkType, string>;
-  linkPointerAreaPaint?: CanvasPointerAreaPaintFn<LinkType>;
+  linkLabel?: Accessor<LinkObjectIntersection<NodeType, LinkType>, string>;
+  linkVisibility?: Accessor<LinkObjectIntersection<NodeType, LinkType>, boolean>;
+  linkColor?: Accessor<LinkObjectIntersection<NodeType, LinkType>, string>;
+  linkAutoColorBy?: Accessor<LinkObjectIntersection<NodeType, LinkType>, string | null>;
+  linkLineDash?: Accessor<LinkObjectIntersection<NodeType, LinkType>, number[] | null>;
+  linkWidth?: Accessor<LinkObjectIntersection<NodeType, LinkType>, number>;
+  linkCurvature?: Accessor<LinkObjectIntersection<NodeType, LinkType>, number>;
+  linkCanvasObject?: CanvasCustomRenderFn<LinkObjectIntersection<NodeType, LinkType>>;
+  linkCanvasObjectMode?: string | ((obj: LinkObjectIntersection<NodeType, LinkType>) => CanvasCustomRenderMode | any);
+  linkDirectionalArrowLength?: Accessor<LinkObjectIntersection<NodeType, LinkType>, number>;
+  linkDirectionalArrowColor?: Accessor<LinkObjectIntersection<NodeType, LinkType>, string>;
+  linkDirectionalArrowRelPos?: Accessor<LinkObjectIntersection<NodeType, LinkType>, number>;
+  linkDirectionalParticles?: Accessor<LinkObjectIntersection<NodeType, LinkType>, number>;
+  linkDirectionalParticleSpeed?: Accessor<LinkObjectIntersection<NodeType, LinkType>, number>;
+  linkDirectionalParticleWidth?: Accessor<LinkObjectIntersection<NodeType, LinkType>, number>;
+  linkDirectionalParticleColor?: Accessor<LinkObjectIntersection<NodeType, LinkType>, string>;
+  linkPointerAreaPaint?: CanvasPointerAreaPaintFn<LinkObjectIntersection<NodeType, LinkType>>;
 
   // Render control
   autoPauseRedraw?: boolean;
@@ -90,7 +94,7 @@ export interface ForceGraphProps<
   // Force engine (d3-force) configuration
   dagMode?: DagMode;
   dagLevelDistance?: number | null;
-  dagNodeFilter?: (node: NodeType) => boolean;
+  dagNodeFilter?: (node: NodeObjectIntersection<NodeType>) => boolean;
   onDagError?: ((loopNodeIds: (string | number)[]) => void) | undefined;
   d3AlphaMin?: number;
   d3AlphaDecay?: number;
@@ -103,14 +107,14 @@ export interface ForceGraphProps<
   onEngineStop?: () => void;
 
   // Interaction
-  onNodeClick?: (node: NodeType, event: MouseEvent) => void;
-  onNodeRightClick?: (node: NodeType, event: MouseEvent) => void;
-  onNodeHover?: (node: NodeType | null, previousNode: NodeType | null) => void;
-  onNodeDrag?: (node: NodeType, translate: { x: number, y: number }) => void;
-  onNodeDragEnd?: (node: NodeType, translate: { x: number, y: number }) => void;
-  onLinkClick?: (link: LinkType, event: MouseEvent) => void;
-  onLinkRightClick?: (link: LinkType, event: MouseEvent) => void;
-  onLinkHover?: (link: LinkType | null, previousLink: LinkType | null) => void;
+  onNodeClick?: (node: NodeObjectIntersection<NodeType>, event: MouseEvent) => void;
+  onNodeRightClick?: (node: NodeObjectIntersection<NodeType>, event: MouseEvent) => void;
+  onNodeHover?: (node: NodeObjectIntersection<NodeType> | null, previousNode: NodeObjectIntersection<NodeType> | null) => void;
+  onNodeDrag?: (node: NodeObjectIntersection<NodeType>, translate: { x: number, y: number }) => void;
+  onNodeDragEnd?: (node: NodeObjectIntersection<NodeType>, translate: { x: number, y: number }) => void;
+  onLinkClick?: (link: LinkObjectIntersection<NodeType, LinkType>, event: MouseEvent) => void;
+  onLinkRightClick?: (link: LinkObjectIntersection<NodeType, LinkType>, event: MouseEvent) => void;
+  onLinkHover?: (link: LinkObjectIntersection<NodeType, LinkType> | null, previousLink: LinkObjectIntersection<NodeType, LinkType> | null) => void;
   linkHoverPrecision?: number;
   onBackgroundClick?: (event: MouseEvent) => void;
   onBackgroundRightClick?: (event: MouseEvent) => void;
@@ -123,15 +127,15 @@ export interface ForceGraphProps<
 }
 
 export interface ForceGraphMethods<
-  NodeType extends NodeObject,
-  LinkType extends LinkObject<NodeType>
+  NodeType,
+  LinkType
 > {
   // Link styling
-  emitParticle(link: LinkType): ForceGraphKapsuleInstance;
+  emitParticle(link: LinkObjectIntersection<NodeType, LinkType>): ForceGraphKapsuleInstance;
 
   // Force engine (d3-force) configuration
-  d3Force(forceName: 'link' | 'charge' | 'center' | string): ForceFn<NodeType> | undefined;
-  d3Force(forceName: 'link' | 'charge' | 'center' | string, forceFn: ForceFn<NodeType>): ForceGraphKapsuleInstance;
+  d3Force(forceName: 'link' | 'charge' | 'center' | string): ForceFn<NodeObjectIntersection<NodeType>> | undefined;
+  d3Force(forceName: 'link' | 'charge' | 'center' | string, forceFn: ForceFn<NodeObjectIntersection<NodeType>>): ForceGraphKapsuleInstance;
   d3ReheatSimulation(): ForceGraphKapsuleInstance;
 
   // Render control
@@ -141,15 +145,15 @@ export interface ForceGraphMethods<
   centerAt(x?: number, y?: number, durationMs?: number): ForceGraphKapsuleInstance;
   zoom(): number;
   zoom(scale: number, durationMs?: number): ForceGraphKapsuleInstance;
-  zoomToFit(durationMs?: number, padding?: number, nodeFilter?: (node: NodeType) => boolean): ForceGraphKapsuleInstance;
+  zoomToFit(durationMs?: number, padding?: number, nodeFilter?: (node: NodeObjectIntersection<NodeType>) => boolean): ForceGraphKapsuleInstance;
 
   // Utility
-  getGraphBbox(nodeFilter?: (node: NodeType) => boolean): { x: [number, number], y: [number, number] };
+  getGraphBbox(nodeFilter?: (node: NodeObjectIntersection<NodeType>) => boolean): { x: [number, number], y: [number, number] };
   screen2GraphCoords(x: number, y: number): { x: number, y: number };
   graph2ScreenCoords(x: number, y: number): { x: number, y: number };
 }
 
-type FCwithRef = <NodeType extends NodeObject, LinkType extends LinkObject<NodeType>>(props: ForceGraphProps<NodeType, LinkType> & { ref?: React.MutableRefObject<ForceGraphMethods<NodeType, LinkType> | undefined>; }) => React.ReactElement;
+type FCwithRef = <NodeType, LinkType>(props: ForceGraphProps<NodeObjectIntersection<NodeType>, LinkObjectIntersection<NodeType, LinkType>> & { ref?: React.MutableRefObject<ForceGraphMethods<NodeObjectIntersection<NodeType>, LinkObjectIntersection<NodeType, LinkType>> | undefined>; }) => React.ReactElement;
 
 declare const ForceGraph: FCwithRef;
 

--- a/src/packages/react-force-graph-2d/index.d.ts
+++ b/src/packages/react-force-graph-2d/index.d.ts
@@ -1,9 +1,9 @@
 import * as React from 'react';
 import { ForceGraphInstance as ForceGraphKapsuleInstance } from 'force-graph';
 
-export interface GraphData<Node extends NodeObject, Link extends LinkObject<Node>> {
-  nodes: Node[];
-  links: Link[];
+export interface GraphData<NodeType extends NodeObject, LinkType extends LinkObject<NodeType>> {
+  nodes: NodeType[];
+  links: LinkType[];
 }
 
 export type NodeObject = {
@@ -16,9 +16,9 @@ export type NodeObject = {
   fy?: number;
 };
 
-export type LinkObject<Node extends NodeObject = NodeObject> = {
-  source?: string | number | Node;
-  target?: string | number | Node;
+export type LinkObject<NodeType extends NodeObject = NodeObject> = {
+  source?: string | number | NodeType;
+  target?: string | number | NodeType;
 };
 
 type Accessor<In, Out> = Out | string | ((obj: In) => Out);
@@ -29,18 +29,18 @@ type CanvasPointerAreaPaintFn<T> = (obj: T, paintColor: string, canvasContext: C
 
 type DagMode = 'td' | 'bu' | 'lr' | 'rl' | 'radialout' | 'radialin';
 
-interface ForceFn<Node extends NodeObject> {
+interface ForceFn<NodeType extends NodeObject> {
   (alpha: number): void;
-  initialize?: (nodes: Node[], ...args: any[]) => void;
+  initialize?: (nodes: NodeType[], ...args: any[]) => void;
   [key: string]: any;
 }
 
 export interface ForceGraphProps<
-  Node extends NodeObject,
-  Link extends LinkObject<Node>
+  NodeType extends NodeObject,
+  LinkType extends LinkObject<NodeType>
 > {
   // Data input
-  graphData?: GraphData<Node, Link>;
+  graphData?: GraphData<NodeType, LinkType>;
   nodeId?: string;
   linkSource?: string;
   linkTarget?: string;
@@ -52,33 +52,33 @@ export interface ForceGraphProps<
 
   // Node styling
   nodeRelSize?: number;
-  nodeVal?: Accessor<Node, number>;
-  nodeLabel?: Accessor<Node, string>;
-  nodeVisibility?: Accessor<Node, boolean>;
-  nodeColor?: Accessor<Node, string>;
-  nodeAutoColorBy?: Accessor<Node, string | null>;
-  nodeCanvasObjectMode?: string | ((obj: Node) => CanvasCustomRenderMode | any);
-  nodeCanvasObject?: CanvasCustomRenderFn<Node>;
-  nodePointerAreaPaint?: CanvasPointerAreaPaintFn<Node>;
+  nodeVal?: Accessor<NodeType, number>;
+  nodeLabel?: Accessor<NodeType, string>;
+  nodeVisibility?: Accessor<NodeType, boolean>;
+  nodeColor?: Accessor<NodeType, string>;
+  nodeAutoColorBy?: Accessor<NodeType, string | null>;
+  nodeCanvasObjectMode?: string | ((obj: NodeType) => CanvasCustomRenderMode | any);
+  nodeCanvasObject?: CanvasCustomRenderFn<NodeType>;
+  nodePointerAreaPaint?: CanvasPointerAreaPaintFn<NodeType>;
 
   // Link styling
-  linkLabel?: Accessor<Link, string>;
-  linkVisibility?: Accessor<Link, boolean>;
-  linkColor?: Accessor<Link, string>;
-  linkAutoColorBy?: Accessor<Link, string | null>;
-  linkLineDash?: Accessor<Link, number[] | null>;
-  linkWidth?: Accessor<Link, number>;
-  linkCurvature?: Accessor<Link, number>;
-  linkCanvasObject?: CanvasCustomRenderFn<Link>;
-  linkCanvasObjectMode?: string | ((obj: Link) => CanvasCustomRenderMode | any);
-  linkDirectionalArrowLength?: Accessor<Link, number>;
-  linkDirectionalArrowColor?: Accessor<Link, string>;
-  linkDirectionalArrowRelPos?: Accessor<Link, number>;
-  linkDirectionalParticles?: Accessor<Link, number>;
-  linkDirectionalParticleSpeed?: Accessor<Link, number>;
-  linkDirectionalParticleWidth?: Accessor<Link, number>;
-  linkDirectionalParticleColor?: Accessor<Link, string>;
-  linkPointerAreaPaint?: CanvasPointerAreaPaintFn<Link>;
+  linkLabel?: Accessor<LinkType, string>;
+  linkVisibility?: Accessor<LinkType, boolean>;
+  linkColor?: Accessor<LinkType, string>;
+  linkAutoColorBy?: Accessor<LinkType, string | null>;
+  linkLineDash?: Accessor<LinkType, number[] | null>;
+  linkWidth?: Accessor<LinkType, number>;
+  linkCurvature?: Accessor<LinkType, number>;
+  linkCanvasObject?: CanvasCustomRenderFn<LinkType>;
+  linkCanvasObjectMode?: string | ((obj: LinkType) => CanvasCustomRenderMode | any);
+  linkDirectionalArrowLength?: Accessor<LinkType, number>;
+  linkDirectionalArrowColor?: Accessor<LinkType, string>;
+  linkDirectionalArrowRelPos?: Accessor<LinkType, number>;
+  linkDirectionalParticles?: Accessor<LinkType, number>;
+  linkDirectionalParticleSpeed?: Accessor<LinkType, number>;
+  linkDirectionalParticleWidth?: Accessor<LinkType, number>;
+  linkDirectionalParticleColor?: Accessor<LinkType, string>;
+  linkPointerAreaPaint?: CanvasPointerAreaPaintFn<LinkType>;
 
   // Render control
   autoPauseRedraw?: boolean;
@@ -90,7 +90,7 @@ export interface ForceGraphProps<
   // Force engine (d3-force) configuration
   dagMode?: DagMode;
   dagLevelDistance?: number | null;
-  dagNodeFilter?: (node: Node) => boolean;
+  dagNodeFilter?: (node: NodeType) => boolean;
   onDagError?: ((loopNodeIds: (string | number)[]) => void) | undefined;
   d3AlphaMin?: number;
   d3AlphaDecay?: number;
@@ -103,14 +103,14 @@ export interface ForceGraphProps<
   onEngineStop?: () => void;
 
   // Interaction
-  onNodeClick?: (node: Node, event: MouseEvent) => void;
-  onNodeRightClick?: (node: Node, event: MouseEvent) => void;
-  onNodeHover?: (node: Node | null, previousNode: Node | null) => void;
-  onNodeDrag?: (node: Node, translate: { x: number, y: number }) => void;
-  onNodeDragEnd?: (node: Node, translate: { x: number, y: number }) => void;
-  onLinkClick?: (link: Link, event: MouseEvent) => void;
-  onLinkRightClick?: (link: Link, event: MouseEvent) => void;
-  onLinkHover?: (link: Link | null, previousLink: Link | null) => void;
+  onNodeClick?: (node: NodeType, event: MouseEvent) => void;
+  onNodeRightClick?: (node: NodeType, event: MouseEvent) => void;
+  onNodeHover?: (node: NodeType | null, previousNode: NodeType | null) => void;
+  onNodeDrag?: (node: NodeType, translate: { x: number, y: number }) => void;
+  onNodeDragEnd?: (node: NodeType, translate: { x: number, y: number }) => void;
+  onLinkClick?: (link: LinkType, event: MouseEvent) => void;
+  onLinkRightClick?: (link: LinkType, event: MouseEvent) => void;
+  onLinkHover?: (link: LinkType | null, previousLink: LinkType | null) => void;
   linkHoverPrecision?: number;
   onBackgroundClick?: (event: MouseEvent) => void;
   onBackgroundRightClick?: (event: MouseEvent) => void;
@@ -123,15 +123,15 @@ export interface ForceGraphProps<
 }
 
 export interface ForceGraphMethods<
-  Node extends NodeObject,
-  Link extends LinkObject<Node>
+  NodeType extends NodeObject,
+  LinkType extends LinkObject<NodeType>
 > {
   // Link styling
-  emitParticle(link: Link): ForceGraphKapsuleInstance;
+  emitParticle(link: LinkType): ForceGraphKapsuleInstance;
 
   // Force engine (d3-force) configuration
-  d3Force(forceName: 'link' | 'charge' | 'center' | string): ForceFn<Node> | undefined;
-  d3Force(forceName: 'link' | 'charge' | 'center' | string, forceFn: ForceFn<Node>): ForceGraphKapsuleInstance;
+  d3Force(forceName: 'link' | 'charge' | 'center' | string): ForceFn<NodeType> | undefined;
+  d3Force(forceName: 'link' | 'charge' | 'center' | string, forceFn: ForceFn<NodeType>): ForceGraphKapsuleInstance;
   d3ReheatSimulation(): ForceGraphKapsuleInstance;
 
   // Render control
@@ -141,15 +141,15 @@ export interface ForceGraphMethods<
   centerAt(x?: number, y?: number, durationMs?: number): ForceGraphKapsuleInstance;
   zoom(): number;
   zoom(scale: number, durationMs?: number): ForceGraphKapsuleInstance;
-  zoomToFit(durationMs?: number, padding?: number, nodeFilter?: (node: Node) => boolean): ForceGraphKapsuleInstance;
+  zoomToFit(durationMs?: number, padding?: number, nodeFilter?: (node: NodeType) => boolean): ForceGraphKapsuleInstance;
 
   // Utility
-  getGraphBbox(nodeFilter?: (node: Node) => boolean): { x: [number, number], y: [number, number] };
+  getGraphBbox(nodeFilter?: (node: NodeType) => boolean): { x: [number, number], y: [number, number] };
   screen2GraphCoords(x: number, y: number): { x: number, y: number };
   graph2ScreenCoords(x: number, y: number): { x: number, y: number };
 }
 
-type FCwithRef = <Node extends NodeObject, Link extends LinkObject<Node>>(props: ForceGraphProps<Node, Link> & { ref?: React.MutableRefObject<ForceGraphMethods<Node, Link> | undefined>; }) => React.ReactElement;
+type FCwithRef = <NodeType extends NodeObject, LinkType extends LinkObject<NodeType>>(props: ForceGraphProps<NodeType, LinkType> & { ref?: React.MutableRefObject<ForceGraphMethods<NodeType, LinkType> | undefined>; }) => React.ReactElement;
 
 declare const ForceGraph: FCwithRef;
 

--- a/src/packages/react-force-graph-2d/index.d.ts
+++ b/src/packages/react-force-graph-2d/index.d.ts
@@ -1,12 +1,12 @@
 import * as React from 'react';
 import { ForceGraphInstance as ForceGraphKapsuleInstance } from 'force-graph';
 
-export interface GraphData {
-  nodes: NodeObject[];
-  links: LinkObject[];
+export interface GraphData<Node extends NodeObject, Link extends LinkObject<Node>> {
+  nodes: Node[];
+  links: Link[];
 }
 
-export type NodeObject = object & {
+export type NodeObject = {
   id?: string | number;
   x?: number;
   y?: number;
@@ -16,14 +16,12 @@ export type NodeObject = object & {
   fy?: number;
 };
 
-export type LinkObject = object & {
-  source?: string | number | NodeObject;
-  target?: string | number | NodeObject;
+export type LinkObject<Node extends NodeObject = NodeObject> = {
+  source?: string | number | Node;
+  target?: string | number | Node;
 };
 
 type Accessor<In, Out> = Out | string | ((obj: In) => Out);
-type NodeAccessor<T> = Accessor<NodeObject, T>;
-type LinkAccessor<T> = Accessor<LinkObject, T>;
 
 type CanvasCustomRenderMode = 'replace' | 'before' | 'after';
 type CanvasCustomRenderFn<T> = (obj: T, canvasContext: CanvasRenderingContext2D, globalScale: number) => void;
@@ -31,15 +29,18 @@ type CanvasPointerAreaPaintFn<T> = (obj: T, paintColor: string, canvasContext: C
 
 type DagMode = 'td' | 'bu' | 'lr' | 'rl' | 'radialout' | 'radialin';
 
-interface ForceFn {
+interface ForceFn<Node extends NodeObject> {
   (alpha: number): void;
-  initialize?: (nodes: NodeObject[], ...args: any[]) => void;
+  initialize?: (nodes: Node[], ...args: any[]) => void;
   [key: string]: any;
 }
 
-export interface ForceGraphProps {
+export interface ForceGraphProps<
+  Node extends NodeObject,
+  Link extends LinkObject<Node>
+> {
   // Data input
-  graphData?: GraphData;
+  graphData?: GraphData<Node, Link>;
   nodeId?: string;
   linkSource?: string;
   linkTarget?: string;
@@ -51,33 +52,33 @@ export interface ForceGraphProps {
 
   // Node styling
   nodeRelSize?: number;
-  nodeVal?: NodeAccessor<number>;
-  nodeLabel?: NodeAccessor<string>;
-  nodeVisibility?: NodeAccessor<boolean>;
-  nodeColor?: NodeAccessor<string>;
-  nodeAutoColorBy?: NodeAccessor<string | null>;
-  nodeCanvasObjectMode?: string | ((obj: NodeObject) => CanvasCustomRenderMode | any);
-  nodeCanvasObject?: CanvasCustomRenderFn<NodeObject>;
-  nodePointerAreaPaint?: CanvasPointerAreaPaintFn<NodeObject>;
+  nodeVal?: Accessor<Node, number>;
+  nodeLabel?: Accessor<Node, string>;
+  nodeVisibility?: Accessor<Node, boolean>;
+  nodeColor?: Accessor<Node, string>;
+  nodeAutoColorBy?: Accessor<Node, string | null>;
+  nodeCanvasObjectMode?: string | ((obj: Node) => CanvasCustomRenderMode | any);
+  nodeCanvasObject?: CanvasCustomRenderFn<Node>;
+  nodePointerAreaPaint?: CanvasPointerAreaPaintFn<Node>;
 
   // Link styling
-  linkLabel?: LinkAccessor<string>;
-  linkVisibility?: LinkAccessor<boolean>;
-  linkColor?: LinkAccessor<string>;
-  linkAutoColorBy?: LinkAccessor<string | null>;
-  linkLineDash?: LinkAccessor<number[] | null>;
-  linkWidth?: LinkAccessor<number>;
-  linkCurvature?: LinkAccessor<number>;
-  linkCanvasObject?: CanvasCustomRenderFn<LinkObject>;
-  linkCanvasObjectMode?: string | ((obj: LinkObject) => CanvasCustomRenderMode | any);
-  linkDirectionalArrowLength?: LinkAccessor<number>;
-  linkDirectionalArrowColor?: LinkAccessor<string>;
-  linkDirectionalArrowRelPos?: LinkAccessor<number>;
-  linkDirectionalParticles?: LinkAccessor<number>;
-  linkDirectionalParticleSpeed?: LinkAccessor<number>;
-  linkDirectionalParticleWidth?: LinkAccessor<number>;
-  linkDirectionalParticleColor?: LinkAccessor<string>;
-  linkPointerAreaPaint?: CanvasPointerAreaPaintFn<LinkObject>;
+  linkLabel?: Accessor<Link, string>;
+  linkVisibility?: Accessor<Link, boolean>;
+  linkColor?: Accessor<Link, string>;
+  linkAutoColorBy?: Accessor<Link, string | null>;
+  linkLineDash?: Accessor<Link, number[] | null>;
+  linkWidth?: Accessor<Link, number>;
+  linkCurvature?: Accessor<Link, number>;
+  linkCanvasObject?: CanvasCustomRenderFn<Link>;
+  linkCanvasObjectMode?: string | ((obj: Link) => CanvasCustomRenderMode | any);
+  linkDirectionalArrowLength?: Accessor<Link, number>;
+  linkDirectionalArrowColor?: Accessor<Link, string>;
+  linkDirectionalArrowRelPos?: Accessor<Link, number>;
+  linkDirectionalParticles?: Accessor<Link, number>;
+  linkDirectionalParticleSpeed?: Accessor<Link, number>;
+  linkDirectionalParticleWidth?: Accessor<Link, number>;
+  linkDirectionalParticleColor?: Accessor<Link, string>;
+  linkPointerAreaPaint?: CanvasPointerAreaPaintFn<Link>;
 
   // Render control
   autoPauseRedraw?: boolean;
@@ -89,7 +90,7 @@ export interface ForceGraphProps {
   // Force engine (d3-force) configuration
   dagMode?: DagMode;
   dagLevelDistance?: number | null;
-  dagNodeFilter?: (node: NodeObject) => boolean;
+  dagNodeFilter?: (node: Node) => boolean;
   onDagError?: ((loopNodeIds: (string | number)[]) => void) | undefined;
   d3AlphaMin?: number;
   d3AlphaDecay?: number;
@@ -102,14 +103,14 @@ export interface ForceGraphProps {
   onEngineStop?: () => void;
 
   // Interaction
-  onNodeClick?: (node: NodeObject, event: MouseEvent) => void;
-  onNodeRightClick?: (node: NodeObject, event: MouseEvent) => void;
-  onNodeHover?: (node: NodeObject | null, previousNode: NodeObject | null) => void;
-  onNodeDrag?: (node: NodeObject, translate: { x: number, y: number }) => void;
-  onNodeDragEnd?: (node: NodeObject, translate: { x: number, y: number }) => void;
-  onLinkClick?: (link: LinkObject, event: MouseEvent) => void;
-  onLinkRightClick?: (link: LinkObject, event: MouseEvent) => void;
-  onLinkHover?: (link: LinkObject | null, previousLink: LinkObject | null) => void;
+  onNodeClick?: (node: Node, event: MouseEvent) => void;
+  onNodeRightClick?: (node: Node, event: MouseEvent) => void;
+  onNodeHover?: (node: Node | null, previousNode: Node | null) => void;
+  onNodeDrag?: (node: Node, translate: { x: number, y: number }) => void;
+  onNodeDragEnd?: (node: Node, translate: { x: number, y: number }) => void;
+  onLinkClick?: (link: Link, event: MouseEvent) => void;
+  onLinkRightClick?: (link: Link, event: MouseEvent) => void;
+  onLinkHover?: (link: Link | null, previousLink: Link | null) => void;
   linkHoverPrecision?: number;
   onBackgroundClick?: (event: MouseEvent) => void;
   onBackgroundRightClick?: (event: MouseEvent) => void;
@@ -121,13 +122,16 @@ export interface ForceGraphProps {
   enablePointerInteraction?: boolean;
 }
 
-export interface ForceGraphMethods {
+export interface ForceGraphMethods<
+  Node extends NodeObject,
+  Link extends LinkObject<Node>
+> {
   // Link styling
-  emitParticle(link: LinkObject): ForceGraphKapsuleInstance;
+  emitParticle(link: Link): ForceGraphKapsuleInstance;
 
   // Force engine (d3-force) configuration
-  d3Force(forceName: 'link' | 'charge' | 'center' | string): ForceFn | undefined;
-  d3Force(forceName: 'link' | 'charge' | 'center' | string, forceFn: ForceFn): ForceGraphKapsuleInstance;
+  d3Force(forceName: 'link' | 'charge' | 'center' | string): ForceFn<Node> | undefined;
+  d3Force(forceName: 'link' | 'charge' | 'center' | string, forceFn: ForceFn<Node>): ForceGraphKapsuleInstance;
   d3ReheatSimulation(): ForceGraphKapsuleInstance;
 
   // Render control
@@ -137,16 +141,16 @@ export interface ForceGraphMethods {
   centerAt(x?: number, y?: number, durationMs?: number): ForceGraphKapsuleInstance;
   zoom(): number;
   zoom(scale: number, durationMs?: number): ForceGraphKapsuleInstance;
-  zoomToFit(durationMs?: number, padding?: number, nodeFilter?: (node: NodeObject) => boolean): ForceGraphKapsuleInstance;
+  zoomToFit(durationMs?: number, padding?: number, nodeFilter?: (node: Node) => boolean): ForceGraphKapsuleInstance;
 
   // Utility
-  getGraphBbox(nodeFilter?: (node: NodeObject) => boolean): { x: [number, number], y: [number, number] };
+  getGraphBbox(nodeFilter?: (node: Node) => boolean): { x: [number, number], y: [number, number] };
   screen2GraphCoords(x: number, y: number): { x: number, y: number };
   graph2ScreenCoords(x: number, y: number): { x: number, y: number };
 }
 
-type FCwithRef<P = {}, R = {}> = React.FunctionComponent<P & { ref?: React.MutableRefObject<R | undefined> }>;
+type FCwithRef = <Node extends NodeObject, Link extends LinkObject<Node>>(props: ForceGraphProps<Node, Link> & { ref?: React.MutableRefObject<ForceGraphMethods<Node, Link> | undefined>; }) => React.ReactElement;
 
-declare const ForceGraph: FCwithRef<ForceGraphProps, ForceGraphMethods>;
+declare const ForceGraph: FCwithRef;
 
 export default ForceGraph;

--- a/src/packages/react-force-graph-2d/index.d.ts
+++ b/src/packages/react-force-graph-2d/index.d.ts
@@ -16,7 +16,7 @@ export type NodeObject = {
   fy?: number;
 };
 
-export type LinkObject<NodeType extends NodeObject = NodeObject> = {
+export type LinkObject<NodeType extends NodeObject> = {
   source?: string | number | NodeType;
   target?: string | number | NodeType;
 };

--- a/src/packages/react-force-graph-2d/index.d.ts
+++ b/src/packages/react-force-graph-2d/index.d.ts
@@ -24,6 +24,8 @@ export type LinkObject<NodeType = {}, LinkType = {}> = LinkType & {
 };
 
 type Accessor<In, Out> = Out | string | ((obj: In) => Out);
+type NodeAccessor<NodeType, T> = Accessor<NodeObject<NodeType>, T>;
+type LinkAccessor<NodeType, LinkType, T> = Accessor<LinkObject<NodeType, LinkType>, T>;
 
 type CanvasCustomRenderMode = 'replace' | 'before' | 'after';
 type CanvasCustomRenderFn<T> = (obj: T, canvasContext: CanvasRenderingContext2D, globalScale: number) => void;
@@ -54,32 +56,32 @@ export interface ForceGraphProps<
 
   // Node styling
   nodeRelSize?: number;
-  nodeVal?: Accessor<NodeObject<NodeType>, number>;
-  nodeLabel?: Accessor<NodeObject<NodeType>, string>;
-  nodeVisibility?: Accessor<NodeObject<NodeType>, boolean>;
-  nodeColor?: Accessor<NodeObject<NodeType>, string>;
-  nodeAutoColorBy?: Accessor<NodeObject<NodeType>, string | null>;
+  nodeVal?: NodeAccessor<NodeType, number>;
+  nodeLabel?: NodeAccessor<NodeType, string>;
+  nodeVisibility?: NodeAccessor<NodeType, boolean>;
+  nodeColor?: NodeAccessor<NodeType, string>;
+  nodeAutoColorBy?: NodeAccessor<NodeType, string | null>;
   nodeCanvasObjectMode?: string | ((obj: NodeObject<NodeType>) => CanvasCustomRenderMode | any);
   nodeCanvasObject?: CanvasCustomRenderFn<NodeObject<NodeType>>;
   nodePointerAreaPaint?: CanvasPointerAreaPaintFn<NodeObject<NodeType>>;
 
   // Link styling
-  linkLabel?: Accessor<LinkObject<NodeType, LinkType>, string>;
-  linkVisibility?: Accessor<LinkObject<NodeType, LinkType>, boolean>;
-  linkColor?: Accessor<LinkObject<NodeType, LinkType>, string>;
-  linkAutoColorBy?: Accessor<LinkObject<NodeType, LinkType>, string | null>;
-  linkLineDash?: Accessor<LinkObject<NodeType, LinkType>, number[] | null>;
-  linkWidth?: Accessor<LinkObject<NodeType, LinkType>, number>;
-  linkCurvature?: Accessor<LinkObject<NodeType, LinkType>, number>;
+  linkLabel?: LinkAccessor<NodeType, LinkType, string>;
+  linkVisibility?: LinkAccessor<NodeType, LinkType, boolean>;
+  linkColor?: LinkAccessor<NodeType, LinkType, string>;
+  linkAutoColorBy?: LinkAccessor<NodeType, LinkType, string | null>;
+  linkLineDash?: LinkAccessor<NodeType, LinkType, number[] | null>;
+  linkWidth?: LinkAccessor<NodeType, LinkType, number>;
+  linkCurvature?: LinkAccessor<NodeType, LinkType, number>;
   linkCanvasObject?: CanvasCustomRenderFn<LinkObject<NodeType, LinkType>>;
   linkCanvasObjectMode?: string | ((obj: LinkObject<NodeType, LinkType>) => CanvasCustomRenderMode | any);
-  linkDirectionalArrowLength?: Accessor<LinkObject<NodeType, LinkType>, number>;
-  linkDirectionalArrowColor?: Accessor<LinkObject<NodeType, LinkType>, string>;
-  linkDirectionalArrowRelPos?: Accessor<LinkObject<NodeType, LinkType>, number>;
-  linkDirectionalParticles?: Accessor<LinkObject<NodeType, LinkType>, number>;
-  linkDirectionalParticleSpeed?: Accessor<LinkObject<NodeType, LinkType>, number>;
-  linkDirectionalParticleWidth?: Accessor<LinkObject<NodeType, LinkType>, number>;
-  linkDirectionalParticleColor?: Accessor<LinkObject<NodeType, LinkType>, string>;
+  linkDirectionalArrowLength?: LinkAccessor<NodeType, LinkType, number>;
+  linkDirectionalArrowColor?: LinkAccessor<NodeType, LinkType, string>;
+  linkDirectionalArrowRelPos?: LinkAccessor<NodeType, LinkType, number>;
+  linkDirectionalParticles?: LinkAccessor<NodeType, LinkType, number>;
+  linkDirectionalParticleSpeed?: LinkAccessor<NodeType, LinkType, number>;
+  linkDirectionalParticleWidth?: LinkAccessor<NodeType, LinkType, number>;
+  linkDirectionalParticleColor?: LinkAccessor<NodeType, LinkType, string>;
   linkPointerAreaPaint?: CanvasPointerAreaPaintFn<LinkObject<NodeType, LinkType>>;
 
   // Render control

--- a/src/packages/react-force-graph-2d/index.d.ts
+++ b/src/packages/react-force-graph-2d/index.d.ts
@@ -2,11 +2,11 @@ import * as React from 'react';
 import { ForceGraphInstance as ForceGraphKapsuleInstance } from 'force-graph';
 
 export interface GraphData<NodeType = {}, LinkType = {}> {
-  nodes: NodeObjectIntersection<NodeType>[];
-  links: LinkObjectIntersection<NodeType, LinkType>[];
+  nodes: NodeObject<NodeType>[];
+  links: LinkObject<NodeType, LinkType>[];
 }
 
-export type NodeObject = {
+export type NodeObject<NodeType = {}> = NodeType & {
   id?: string | number;
   x?: number;
   y?: number;
@@ -14,16 +14,14 @@ export type NodeObject = {
   vy?: number;
   fx?: number;
   fy?: number;
+  [others: string]: any;
 };
 
-type NodeObjectIntersection<NodeType> = NodeType & NodeObject & { [others: string]: any; };
-
-export type LinkObject<NodeType = {}> = {
-  source?: string | number | NodeObjectIntersection<NodeType>;
-  target?: string | number | NodeObjectIntersection<NodeType>;
+export type LinkObject<NodeType = {}, LinkType = {}> = LinkType & {
+  source?: string | number | NodeObject<NodeType>;
+  target?: string | number | NodeObject<NodeType>;
+  [others: string]: any;
 };
-
-type LinkObjectIntersection<NodeType, LinkType> = LinkType & LinkObject<NodeType> & { [others: string]: any; };
 
 type Accessor<In, Out> = Out | string | ((obj: In) => Out);
 
@@ -35,7 +33,7 @@ type DagMode = 'td' | 'bu' | 'lr' | 'rl' | 'radialout' | 'radialin';
 
 interface ForceFn<NodeType = {}> {
   (alpha: number): void;
-  initialize?: (nodes: NodeObjectIntersection<NodeType>[], ...args: any[]) => void;
+  initialize?: (nodes: NodeObject<NodeType>[], ...args: any[]) => void;
   [key: string]: any;
 }
 
@@ -44,7 +42,7 @@ export interface ForceGraphProps<
   LinkType = {}
 > {
   // Data input
-  graphData?: GraphData<NodeObjectIntersection<NodeType>, LinkObjectIntersection<NodeType, LinkType>>;
+  graphData?: GraphData<NodeObject<NodeType>, LinkObject<NodeType, LinkType>>;
   nodeId?: string;
   linkSource?: string;
   linkTarget?: string;
@@ -56,33 +54,33 @@ export interface ForceGraphProps<
 
   // Node styling
   nodeRelSize?: number;
-  nodeVal?: Accessor<NodeObjectIntersection<NodeType>, number>;
-  nodeLabel?: Accessor<NodeObjectIntersection<NodeType>, string>;
-  nodeVisibility?: Accessor<NodeObjectIntersection<NodeType>, boolean>;
-  nodeColor?: Accessor<NodeObjectIntersection<NodeType>, string>;
-  nodeAutoColorBy?: Accessor<NodeObjectIntersection<NodeType>, string | null>;
-  nodeCanvasObjectMode?: string | ((obj: NodeObjectIntersection<NodeType>) => CanvasCustomRenderMode | any);
-  nodeCanvasObject?: CanvasCustomRenderFn<NodeObjectIntersection<NodeType>>;
-  nodePointerAreaPaint?: CanvasPointerAreaPaintFn<NodeObjectIntersection<NodeType>>;
+  nodeVal?: Accessor<NodeObject<NodeType>, number>;
+  nodeLabel?: Accessor<NodeObject<NodeType>, string>;
+  nodeVisibility?: Accessor<NodeObject<NodeType>, boolean>;
+  nodeColor?: Accessor<NodeObject<NodeType>, string>;
+  nodeAutoColorBy?: Accessor<NodeObject<NodeType>, string | null>;
+  nodeCanvasObjectMode?: string | ((obj: NodeObject<NodeType>) => CanvasCustomRenderMode | any);
+  nodeCanvasObject?: CanvasCustomRenderFn<NodeObject<NodeType>>;
+  nodePointerAreaPaint?: CanvasPointerAreaPaintFn<NodeObject<NodeType>>;
 
   // Link styling
-  linkLabel?: Accessor<LinkObjectIntersection<NodeType, LinkType>, string>;
-  linkVisibility?: Accessor<LinkObjectIntersection<NodeType, LinkType>, boolean>;
-  linkColor?: Accessor<LinkObjectIntersection<NodeType, LinkType>, string>;
-  linkAutoColorBy?: Accessor<LinkObjectIntersection<NodeType, LinkType>, string | null>;
-  linkLineDash?: Accessor<LinkObjectIntersection<NodeType, LinkType>, number[] | null>;
-  linkWidth?: Accessor<LinkObjectIntersection<NodeType, LinkType>, number>;
-  linkCurvature?: Accessor<LinkObjectIntersection<NodeType, LinkType>, number>;
-  linkCanvasObject?: CanvasCustomRenderFn<LinkObjectIntersection<NodeType, LinkType>>;
-  linkCanvasObjectMode?: string | ((obj: LinkObjectIntersection<NodeType, LinkType>) => CanvasCustomRenderMode | any);
-  linkDirectionalArrowLength?: Accessor<LinkObjectIntersection<NodeType, LinkType>, number>;
-  linkDirectionalArrowColor?: Accessor<LinkObjectIntersection<NodeType, LinkType>, string>;
-  linkDirectionalArrowRelPos?: Accessor<LinkObjectIntersection<NodeType, LinkType>, number>;
-  linkDirectionalParticles?: Accessor<LinkObjectIntersection<NodeType, LinkType>, number>;
-  linkDirectionalParticleSpeed?: Accessor<LinkObjectIntersection<NodeType, LinkType>, number>;
-  linkDirectionalParticleWidth?: Accessor<LinkObjectIntersection<NodeType, LinkType>, number>;
-  linkDirectionalParticleColor?: Accessor<LinkObjectIntersection<NodeType, LinkType>, string>;
-  linkPointerAreaPaint?: CanvasPointerAreaPaintFn<LinkObjectIntersection<NodeType, LinkType>>;
+  linkLabel?: Accessor<LinkObject<NodeType, LinkType>, string>;
+  linkVisibility?: Accessor<LinkObject<NodeType, LinkType>, boolean>;
+  linkColor?: Accessor<LinkObject<NodeType, LinkType>, string>;
+  linkAutoColorBy?: Accessor<LinkObject<NodeType, LinkType>, string | null>;
+  linkLineDash?: Accessor<LinkObject<NodeType, LinkType>, number[] | null>;
+  linkWidth?: Accessor<LinkObject<NodeType, LinkType>, number>;
+  linkCurvature?: Accessor<LinkObject<NodeType, LinkType>, number>;
+  linkCanvasObject?: CanvasCustomRenderFn<LinkObject<NodeType, LinkType>>;
+  linkCanvasObjectMode?: string | ((obj: LinkObject<NodeType, LinkType>) => CanvasCustomRenderMode | any);
+  linkDirectionalArrowLength?: Accessor<LinkObject<NodeType, LinkType>, number>;
+  linkDirectionalArrowColor?: Accessor<LinkObject<NodeType, LinkType>, string>;
+  linkDirectionalArrowRelPos?: Accessor<LinkObject<NodeType, LinkType>, number>;
+  linkDirectionalParticles?: Accessor<LinkObject<NodeType, LinkType>, number>;
+  linkDirectionalParticleSpeed?: Accessor<LinkObject<NodeType, LinkType>, number>;
+  linkDirectionalParticleWidth?: Accessor<LinkObject<NodeType, LinkType>, number>;
+  linkDirectionalParticleColor?: Accessor<LinkObject<NodeType, LinkType>, string>;
+  linkPointerAreaPaint?: CanvasPointerAreaPaintFn<LinkObject<NodeType, LinkType>>;
 
   // Render control
   autoPauseRedraw?: boolean;
@@ -94,7 +92,7 @@ export interface ForceGraphProps<
   // Force engine (d3-force) configuration
   dagMode?: DagMode;
   dagLevelDistance?: number | null;
-  dagNodeFilter?: (node: NodeObjectIntersection<NodeType>) => boolean;
+  dagNodeFilter?: (node: NodeObject<NodeType>) => boolean;
   onDagError?: ((loopNodeIds: (string | number)[]) => void) | undefined;
   d3AlphaMin?: number;
   d3AlphaDecay?: number;
@@ -107,14 +105,14 @@ export interface ForceGraphProps<
   onEngineStop?: () => void;
 
   // Interaction
-  onNodeClick?: (node: NodeObjectIntersection<NodeType>, event: MouseEvent) => void;
-  onNodeRightClick?: (node: NodeObjectIntersection<NodeType>, event: MouseEvent) => void;
-  onNodeHover?: (node: NodeObjectIntersection<NodeType> | null, previousNode: NodeObjectIntersection<NodeType> | null) => void;
-  onNodeDrag?: (node: NodeObjectIntersection<NodeType>, translate: { x: number, y: number }) => void;
-  onNodeDragEnd?: (node: NodeObjectIntersection<NodeType>, translate: { x: number, y: number }) => void;
-  onLinkClick?: (link: LinkObjectIntersection<NodeType, LinkType>, event: MouseEvent) => void;
-  onLinkRightClick?: (link: LinkObjectIntersection<NodeType, LinkType>, event: MouseEvent) => void;
-  onLinkHover?: (link: LinkObjectIntersection<NodeType, LinkType> | null, previousLink: LinkObjectIntersection<NodeType, LinkType> | null) => void;
+  onNodeClick?: (node: NodeObject<NodeType>, event: MouseEvent) => void;
+  onNodeRightClick?: (node: NodeObject<NodeType>, event: MouseEvent) => void;
+  onNodeHover?: (node: NodeObject<NodeType> | null, previousNode: NodeObject<NodeType> | null) => void;
+  onNodeDrag?: (node: NodeObject<NodeType>, translate: { x: number, y: number }) => void;
+  onNodeDragEnd?: (node: NodeObject<NodeType>, translate: { x: number, y: number }) => void;
+  onLinkClick?: (link: LinkObject<NodeType, LinkType>, event: MouseEvent) => void;
+  onLinkRightClick?: (link: LinkObject<NodeType, LinkType>, event: MouseEvent) => void;
+  onLinkHover?: (link: LinkObject<NodeType, LinkType> | null, previousLink: LinkObject<NodeType, LinkType> | null) => void;
   linkHoverPrecision?: number;
   onBackgroundClick?: (event: MouseEvent) => void;
   onBackgroundRightClick?: (event: MouseEvent) => void;
@@ -131,11 +129,11 @@ export interface ForceGraphMethods<
   LinkType = {}
 > {
   // Link styling
-  emitParticle(link: LinkObjectIntersection<NodeType, LinkType>): ForceGraphKapsuleInstance;
+  emitParticle(link: LinkObject<NodeType, LinkType>): ForceGraphKapsuleInstance;
 
   // Force engine (d3-force) configuration
-  d3Force(forceName: 'link' | 'charge' | 'center' | string): ForceFn<NodeObjectIntersection<NodeType>> | undefined;
-  d3Force(forceName: 'link' | 'charge' | 'center' | string, forceFn: ForceFn<NodeObjectIntersection<NodeType>>): ForceGraphKapsuleInstance;
+  d3Force(forceName: 'link' | 'charge' | 'center' | string): ForceFn<NodeObject<NodeType>> | undefined;
+  d3Force(forceName: 'link' | 'charge' | 'center' | string, forceFn: ForceFn<NodeObject<NodeType>>): ForceGraphKapsuleInstance;
   d3ReheatSimulation(): ForceGraphKapsuleInstance;
 
   // Render control
@@ -145,15 +143,15 @@ export interface ForceGraphMethods<
   centerAt(x?: number, y?: number, durationMs?: number): ForceGraphKapsuleInstance;
   zoom(): number;
   zoom(scale: number, durationMs?: number): ForceGraphKapsuleInstance;
-  zoomToFit(durationMs?: number, padding?: number, nodeFilter?: (node: NodeObjectIntersection<NodeType>) => boolean): ForceGraphKapsuleInstance;
+  zoomToFit(durationMs?: number, padding?: number, nodeFilter?: (node: NodeObject<NodeType>) => boolean): ForceGraphKapsuleInstance;
 
   // Utility
-  getGraphBbox(nodeFilter?: (node: NodeObjectIntersection<NodeType>) => boolean): { x: [number, number], y: [number, number] };
+  getGraphBbox(nodeFilter?: (node: NodeObject<NodeType>) => boolean): { x: [number, number], y: [number, number] };
   screen2GraphCoords(x: number, y: number): { x: number, y: number };
   graph2ScreenCoords(x: number, y: number): { x: number, y: number };
 }
 
-type FCwithRef = <NodeType = {}, LinkType = {}>(props: ForceGraphProps<NodeObjectIntersection<NodeType>, LinkObjectIntersection<NodeType, LinkType>> & { ref?: React.MutableRefObject<ForceGraphMethods<NodeObjectIntersection<NodeType>, LinkObjectIntersection<NodeType, LinkType>> | undefined>; }) => React.ReactElement;
+type FCwithRef = <NodeType = {}, LinkType = {}>(props: ForceGraphProps<NodeObject<NodeType>, LinkObject<NodeType, LinkType>> & { ref?: React.MutableRefObject<ForceGraphMethods<NodeObject<NodeType>, LinkObject<NodeType, LinkType>> | undefined>; }) => React.ReactElement;
 
 declare const ForceGraph: FCwithRef;
 

--- a/src/packages/react-force-graph-2d/index.d.ts
+++ b/src/packages/react-force-graph-2d/index.d.ts
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { ForceGraphInstance as ForceGraphKapsuleInstance } from 'force-graph';
 
-export interface GraphData<NodeType, LinkType> {
+export interface GraphData<NodeType = {}, LinkType = {}> {
   nodes: NodeObjectIntersection<NodeType>[];
   links: LinkObjectIntersection<NodeType, LinkType>[];
 }
@@ -18,7 +18,7 @@ export type NodeObject = {
 
 type NodeObjectIntersection<NodeType> = NodeType & NodeObject;
 
-export type LinkObject<NodeType> = {
+export type LinkObject<NodeType = {}> = {
   source?: string | number | NodeObjectIntersection<NodeType>;
   target?: string | number | NodeObjectIntersection<NodeType>;
 };
@@ -33,15 +33,15 @@ type CanvasPointerAreaPaintFn<T> = (obj: T, paintColor: string, canvasContext: C
 
 type DagMode = 'td' | 'bu' | 'lr' | 'rl' | 'radialout' | 'radialin';
 
-interface ForceFn<NodeType> {
+interface ForceFn<NodeType = {}> {
   (alpha: number): void;
   initialize?: (nodes: NodeObjectIntersection<NodeType>[], ...args: any[]) => void;
   [key: string]: any;
 }
 
 export interface ForceGraphProps<
-  NodeType,
-  LinkType
+  NodeType = {},
+  LinkType = {}
 > {
   // Data input
   graphData?: GraphData<NodeObjectIntersection<NodeType>, LinkObjectIntersection<NodeType, LinkType>>;
@@ -127,8 +127,8 @@ export interface ForceGraphProps<
 }
 
 export interface ForceGraphMethods<
-  NodeType,
-  LinkType
+  NodeType = {},
+  LinkType = {}
 > {
   // Link styling
   emitParticle(link: LinkObjectIntersection<NodeType, LinkType>): ForceGraphKapsuleInstance;
@@ -153,7 +153,7 @@ export interface ForceGraphMethods<
   graph2ScreenCoords(x: number, y: number): { x: number, y: number };
 }
 
-type FCwithRef = <NodeType, LinkType>(props: ForceGraphProps<NodeObjectIntersection<NodeType>, LinkObjectIntersection<NodeType, LinkType>> & { ref?: React.MutableRefObject<ForceGraphMethods<NodeObjectIntersection<NodeType>, LinkObjectIntersection<NodeType, LinkType>> | undefined>; }) => React.ReactElement;
+type FCwithRef = <NodeType = {}, LinkType = {}>(props: ForceGraphProps<NodeObjectIntersection<NodeType>, LinkObjectIntersection<NodeType, LinkType>> & { ref?: React.MutableRefObject<ForceGraphMethods<NodeObjectIntersection<NodeType>, LinkObjectIntersection<NodeType, LinkType>> | undefined>; }) => React.ReactElement;
 
 declare const ForceGraph: FCwithRef;
 

--- a/src/packages/react-force-graph-3d/index.d.ts
+++ b/src/packages/react-force-graph-3d/index.d.ts
@@ -73,27 +73,27 @@ export interface ForceGraphProps<
   nodeThreeObjectExtend?: Accessor<NodeObject<NodeType>, boolean>;
 
   // Link styling
-  linkLabel?: Accessor<LinkType, string>;
-  linkVisibility?: Accessor<LinkType, boolean>;
-  linkColor?: Accessor<LinkType, string>;
-  linkAutoColorBy?: Accessor<LinkType, string | null>;
-  linkWidth?: Accessor<LinkType, number>;
+  linkLabel?: Accessor<LinkObject<NodeType, LinkType>, string>;
+  linkVisibility?: Accessor<LinkObject<NodeType, LinkType>, boolean>;
+  linkColor?: Accessor<LinkObject<NodeType, LinkType>, string>;
+  linkAutoColorBy?: Accessor<LinkObject<NodeType, LinkType>, string | null>;
+  linkWidth?: Accessor<LinkObject<NodeType, LinkType>, number>;
   linkOpacity?: number;
   linkResolution?: number;
-  linkCurvature?: Accessor<LinkType, number>;
-  linkCurveRotation?: Accessor<LinkType, number>;
-  linkMaterial?: Accessor<LinkType, Material | boolean | null>;
-  linkThreeObject?: Accessor<LinkType, Object3D>;
-  linkThreeObjectExtend?: Accessor<LinkType, boolean>;
+  linkCurvature?: Accessor<LinkObject<NodeType, LinkType>, number>;
+  linkCurveRotation?: Accessor<LinkObject<NodeType, LinkType>, number>;
+  linkMaterial?: Accessor<LinkObject<NodeType, LinkType>, Material | boolean | null>;
+  linkThreeObject?: Accessor<LinkObject<NodeType, LinkType>, Object3D>;
+  linkThreeObjectExtend?: Accessor<LinkObject<NodeType, LinkType>, boolean>;
   linkPositionUpdate?: LinkPositionUpdateFn | null;
-  linkDirectionalArrowLength?: Accessor<LinkType, number>;
-  linkDirectionalArrowColor?: Accessor<LinkType, string>;
-  linkDirectionalArrowRelPos?: Accessor<LinkType, number>;
+  linkDirectionalArrowLength?: Accessor<LinkObject<NodeType, LinkType>, number>;
+  linkDirectionalArrowColor?: Accessor<LinkObject<NodeType, LinkType>, string>;
+  linkDirectionalArrowRelPos?: Accessor<LinkObject<NodeType, LinkType>, number>;
   linkDirectionalArrowResolution?: number;
-  linkDirectionalParticles?: Accessor<LinkType, number>;
-  linkDirectionalParticleSpeed?: Accessor<LinkType, number>;
-  linkDirectionalParticleWidth?: Accessor<LinkType, number>;
-  linkDirectionalParticleColor?: Accessor<LinkType, string>;
+  linkDirectionalParticles?: Accessor<LinkObject<NodeType, LinkType>, number>;
+  linkDirectionalParticleSpeed?: Accessor<LinkObject<NodeType, LinkType>, number>;
+  linkDirectionalParticleWidth?: Accessor<LinkObject<NodeType, LinkType>, number>;
+  linkDirectionalParticleColor?: Accessor<LinkObject<NodeType, LinkType>, string>;
   linkDirectionalParticleResolution?: number;
 
   // Force engine (d3-force) configuration

--- a/src/packages/react-force-graph-3d/index.d.ts
+++ b/src/packages/react-force-graph-3d/index.d.ts
@@ -121,9 +121,9 @@ export interface ForceGraphProps<
   onNodeHover?: (node: NodeObject<NodeType> | null, previousNode: NodeObject<NodeType> | null) => void;
   onNodeDrag?: (node: NodeObject<NodeType>, translate: { x: number, y: number }) => void;
   onNodeDragEnd?: (node: NodeObject<NodeType>, translate: { x: number, y: number }) => void;
-  onLinkClick?: (link: LinkType, event: MouseEvent) => void;
-  onLinkRightClick?: (link: LinkType, event: MouseEvent) => void;
-  onLinkHover?: (link: LinkType | null, previousLink: LinkType | null) => void;
+  onLinkClick?: (link: LinkObject<NodeType, LinkType>, event: MouseEvent) => void;
+  onLinkRightClick?: (link: LinkObject<NodeType, LinkType>, event: MouseEvent) => void;
+  onLinkHover?: (link: LinkObject<NodeType, LinkType> | null, previousLink: LinkObject<NodeType, LinkType> | null) => void;
   linkHoverPrecision?: number;
   onBackgroundClick?: (event: MouseEvent) => void;
   onBackgroundRightClick?: (event: MouseEvent) => void;
@@ -137,7 +137,7 @@ export interface ForceGraphMethods<
   LinkType = {}
 > {
   // Link styling
-  emitParticle(link: LinkType): ForceGraphKapsuleInstance;
+  emitParticle(link: LinkObject<NodeType, LinkType>): ForceGraphKapsuleInstance;
 
   // Force engine (d3-force) configuration
   d3Force(forceName: 'link' | 'charge' | 'center' | string): ForceFn<NodeObject<NodeType>> | undefined;

--- a/src/packages/react-force-graph-3d/index.d.ts
+++ b/src/packages/react-force-graph-3d/index.d.ts
@@ -3,7 +3,7 @@ import { Scene, Camera, WebGLRenderer, Object3D, Material } from 'three';
 import { EffectComposer } from 'three/examples/jsm/postprocessing/EffectComposer.js';
 import { ConfigOptions, ForceGraph3DInstance as ForceGraphKapsuleInstance } from '3d-force-graph';
 
-export interface GraphData<NodeType, LinkType> {
+export interface GraphData<NodeType = {}, LinkType = {}> {
   nodes: NodeObjectIntersection<NodeType>[];
   links: LinkType[];
 }
@@ -23,7 +23,7 @@ export type NodeObject = {
 
 type NodeObjectIntersection<NodeType> = NodeType & NodeObject;
 
-export type LinkObject<NodeType> = {
+export type LinkObject<NodeType = {}> = {
   source?: string | number | NodeObjectIntersection<NodeType>;
   target?: string | number | NodeObjectIntersection<NodeType>;
 };
@@ -36,7 +36,7 @@ type DagMode = 'td' | 'bu' | 'lr' | 'rl' | 'zout' | 'zin' | 'radialout' | 'radia
 
 type ForceEngine = 'd3' | 'ngraph';
 
-interface ForceFn<NodeType> {
+interface ForceFn<NodeType = {}> {
   (alpha: number): void;
   initialize?: (nodes: NodeObjectIntersection<NodeType>[], ...args: any[]) => void;
   [key: string]: any;
@@ -44,11 +44,11 @@ interface ForceFn<NodeType> {
 
 type Coords = { x: number; y: number; z: number; }
 
-type LinkPositionUpdateFn = <NodeType, LinkType>(obj: Object3D, coords: { start: Coords, end: Coords }, link: LinkObjectIntersection<NodeType, LinkType>) => void | null | boolean;
+type LinkPositionUpdateFn = <NodeType = {}, LinkType = {}>(obj: Object3D, coords: { start: Coords, end: Coords }, link: LinkObjectIntersection<NodeType, LinkType>) => void | null | boolean;
 
 export interface ForceGraphProps<
-  NodeType,
-  LinkType
+  NodeType = {},
+  LinkType = {}
 > extends ConfigOptions {
   // Data input
   graphData?: GraphData<NodeObjectIntersection<NodeType>, LinkObjectIntersection<NodeType, LinkType>>;
@@ -133,8 +133,8 @@ export interface ForceGraphProps<
 }
 
 export interface ForceGraphMethods<
-  NodeType,
-  LinkType
+  NodeType = {},
+  LinkType = {}
 > {
   // Link styling
   emitParticle(link: LinkType): ForceGraphKapsuleInstance;
@@ -162,7 +162,7 @@ export interface ForceGraphMethods<
   graph2ScreenCoords(x: number, y: number, z: number): Coords;
 }
 
-type FCwithRef = <NodeType, LinkType>(props: ForceGraphProps<NodeObjectIntersection<NodeType>, LinkObjectIntersection<NodeType, LinkType>> & { ref?: React.MutableRefObject<ForceGraphMethods<NodeObjectIntersection<NodeType>, LinkObjectIntersection<NodeType, LinkType>> | undefined>; }) => React.ReactElement;
+type FCwithRef = <NodeType = {}, LinkType = {}>(props: ForceGraphProps<NodeObjectIntersection<NodeType>, LinkObjectIntersection<NodeType, LinkType>> & { ref?: React.MutableRefObject<ForceGraphMethods<NodeObjectIntersection<NodeType>, LinkObjectIntersection<NodeType, LinkType>> | undefined>; }) => React.ReactElement;
 
 declare const ForceGraph: FCwithRef;
 

--- a/src/packages/react-force-graph-3d/index.d.ts
+++ b/src/packages/react-force-graph-3d/index.d.ts
@@ -4,11 +4,11 @@ import { EffectComposer } from 'three/examples/jsm/postprocessing/EffectComposer
 import { ConfigOptions, ForceGraph3DInstance as ForceGraphKapsuleInstance } from '3d-force-graph';
 
 export interface GraphData<NodeType = {}, LinkType = {}> {
-  nodes: NodeObjectIntersection<NodeType>[];
-  links: LinkObjectIntersection<NodeType, LinkType>[];
+  nodes: NodeObject<NodeType>[];
+  links: LinkObject<NodeType, LinkType>[];
 }
 
-export type NodeObject = {
+export type NodeObject<NodeType = {}> = NodeType & {
   id?: string | number;
   x?: number;
   y?: number;
@@ -19,16 +19,14 @@ export type NodeObject = {
   fx?: number;
   fy?: number;
   fz?: number;
+  [others: string]: any;
 };
 
-type NodeObjectIntersection<NodeType> = NodeType & NodeObject & { [others: string]: any; };
-
-export type LinkObject<NodeType = {}> = {
-  source?: string | number | NodeObjectIntersection<NodeType>;
-  target?: string | number | NodeObjectIntersection<NodeType>;
+export type LinkObject<NodeType = {}, LinkType = {}> = LinkType & {
+  source?: string | number | NodeObject<NodeType>;
+  target?: string | number | NodeObject<NodeType>;
+  [others: string]: any;
 };
-
-type LinkObjectIntersection<NodeType, LinkType> = LinkType & LinkObject<NodeType> & { [others: string]: any; };
 
 type Accessor<In, Out> = Out | string | ((obj: In) => Out);
 
@@ -38,20 +36,20 @@ type ForceEngine = 'd3' | 'ngraph';
 
 interface ForceFn<NodeType = {}> {
   (alpha: number): void;
-  initialize?: (nodes: NodeObjectIntersection<NodeType>[], ...args: any[]) => void;
+  initialize?: (nodes: NodeObject<NodeType>[], ...args: any[]) => void;
   [key: string]: any;
 }
 
 type Coords = { x: number; y: number; z: number; }
 
-type LinkPositionUpdateFn = <NodeType = {}, LinkType = {}>(obj: Object3D, coords: { start: Coords, end: Coords }, link: LinkObjectIntersection<NodeType, LinkType>) => void | null | boolean;
+type LinkPositionUpdateFn = <NodeType = {}, LinkType = {}>(obj: Object3D, coords: { start: Coords, end: Coords }, link: LinkObject<NodeType, LinkType>) => void | null | boolean;
 
 export interface ForceGraphProps<
   NodeType = {},
   LinkType = {}
 > extends ConfigOptions {
   // Data input
-  graphData?: GraphData<NodeObjectIntersection<NodeType>, LinkObjectIntersection<NodeType, LinkType>>;
+  graphData?: GraphData<NodeObject<NodeType>, LinkObject<NodeType, LinkType>>;
   nodeId?: string;
   linkSource?: string;
   linkTarget?: string;
@@ -64,15 +62,15 @@ export interface ForceGraphProps<
 
   // Node styling
   nodeRelSize?: number;
-  nodeVal?: Accessor<NodeObjectIntersection<NodeType>, number>;
-  nodeLabel?: Accessor<NodeObjectIntersection<NodeType>, string>;
-  nodeVisibility?: Accessor<NodeObjectIntersection<NodeType>, boolean>;
-  nodeColor?: Accessor<NodeObjectIntersection<NodeType>, string>;
-  nodeAutoColorBy?: Accessor<NodeObjectIntersection<NodeType>, string | null>;
+  nodeVal?: Accessor<NodeObject<NodeType>, number>;
+  nodeLabel?: Accessor<NodeObject<NodeType>, string>;
+  nodeVisibility?: Accessor<NodeObject<NodeType>, boolean>;
+  nodeColor?: Accessor<NodeObject<NodeType>, string>;
+  nodeAutoColorBy?: Accessor<NodeObject<NodeType>, string | null>;
   nodeOpacity?: number;
   nodeResolution?: number;
-  nodeThreeObject?: Accessor<NodeObjectIntersection<NodeType>, Object3D>;
-  nodeThreeObjectExtend?: Accessor<NodeObjectIntersection<NodeType>, boolean>;
+  nodeThreeObject?: Accessor<NodeObject<NodeType>, Object3D>;
+  nodeThreeObjectExtend?: Accessor<NodeObject<NodeType>, boolean>;
 
   // Link styling
   linkLabel?: Accessor<LinkType, string>;
@@ -103,7 +101,7 @@ export interface ForceGraphProps<
   numDimensions?: 1 | 2 | 3;
   dagMode?: DagMode;
   dagLevelDistance?: number | null;
-  dagNodeFilter?: (node: NodeObjectIntersection<NodeType>) => boolean;
+  dagNodeFilter?: (node: NodeObject<NodeType>) => boolean;
   onDagError?: ((loopNodeIds: (string | number)[]) => void) | undefined;
   d3AlphaMin?: number;
   d3AlphaDecay?: number;
@@ -116,11 +114,11 @@ export interface ForceGraphProps<
   onEngineStop?: () => void;
 
   // Interaction
-  onNodeClick?: (node: NodeObjectIntersection<NodeType>, event: MouseEvent) => void;
-  onNodeRightClick?: (node: NodeObjectIntersection<NodeType>, event: MouseEvent) => void;
-  onNodeHover?: (node: NodeObjectIntersection<NodeType> | null, previousNode: NodeObjectIntersection<NodeType> | null) => void;
-  onNodeDrag?: (node: NodeObjectIntersection<NodeType>, translate: { x: number, y: number }) => void;
-  onNodeDragEnd?: (node: NodeObjectIntersection<NodeType>, translate: { x: number, y: number }) => void;
+  onNodeClick?: (node: NodeObject<NodeType>, event: MouseEvent) => void;
+  onNodeRightClick?: (node: NodeObject<NodeType>, event: MouseEvent) => void;
+  onNodeHover?: (node: NodeObject<NodeType> | null, previousNode: NodeObject<NodeType> | null) => void;
+  onNodeDrag?: (node: NodeObject<NodeType>, translate: { x: number, y: number }) => void;
+  onNodeDragEnd?: (node: NodeObject<NodeType>, translate: { x: number, y: number }) => void;
   onLinkClick?: (link: LinkType, event: MouseEvent) => void;
   onLinkRightClick?: (link: LinkType, event: MouseEvent) => void;
   onLinkHover?: (link: LinkType | null, previousLink: LinkType | null) => void;
@@ -140,15 +138,15 @@ export interface ForceGraphMethods<
   emitParticle(link: LinkType): ForceGraphKapsuleInstance;
 
   // Force engine (d3-force) configuration
-  d3Force(forceName: 'link' | 'charge' | 'center' | string): ForceFn<NodeObjectIntersection<NodeType>> | undefined;
-  d3Force(forceName: 'link' | 'charge' | 'center' | string, forceFn: ForceFn<NodeObjectIntersection<NodeType>>): ForceGraphKapsuleInstance;
+  d3Force(forceName: 'link' | 'charge' | 'center' | string): ForceFn<NodeObject<NodeType>> | undefined;
+  d3Force(forceName: 'link' | 'charge' | 'center' | string, forceFn: ForceFn<NodeObject<NodeType>>): ForceGraphKapsuleInstance;
   d3ReheatSimulation(): ForceGraphKapsuleInstance;
 
   // Render control
   pauseAnimation(): ForceGraphKapsuleInstance;
   resumeAnimation(): ForceGraphKapsuleInstance;
   cameraPosition(position: Partial<Coords>, lookAt?: Coords, transitionMs?: number): ForceGraphKapsuleInstance;
-  zoomToFit(durationMs?: number, padding?: number, nodeFilter?: (node: NodeObjectIntersection<NodeType>) => boolean): ForceGraphKapsuleInstance;
+  zoomToFit(durationMs?: number, padding?: number, nodeFilter?: (node: NodeObject<NodeType>) => boolean): ForceGraphKapsuleInstance;
   postProcessingComposer(): EffectComposer;
   scene(): Scene;
   camera(): Camera;
@@ -157,12 +155,12 @@ export interface ForceGraphMethods<
   refresh(): ForceGraphKapsuleInstance;
 
   // Utility
-  getGraphBbox(nodeFilter?: (node: NodeObjectIntersection<NodeType>) => boolean): { x: [number, number], y: [number, number], z: [number, number] };
+  getGraphBbox(nodeFilter?: (node: NodeObject<NodeType>) => boolean): { x: [number, number], y: [number, number], z: [number, number] };
   screen2GraphCoords(x: number, y: number, distance: number): Coords;
   graph2ScreenCoords(x: number, y: number, z: number): Coords;
 }
 
-type FCwithRef = <NodeType = {}, LinkType = {}>(props: ForceGraphProps<NodeObjectIntersection<NodeType>, LinkObjectIntersection<NodeType, LinkType>> & { ref?: React.MutableRefObject<ForceGraphMethods<NodeObjectIntersection<NodeType>, LinkObjectIntersection<NodeType, LinkType>> | undefined>; }) => React.ReactElement;
+type FCwithRef = <NodeType = {}, LinkType = {}>(props: ForceGraphProps<NodeObject<NodeType>, LinkObject<NodeType, LinkType>> & { ref?: React.MutableRefObject<ForceGraphMethods<NodeObject<NodeType>, LinkObject<NodeType, LinkType>> | undefined>; }) => React.ReactElement;
 
 declare const ForceGraph: FCwithRef;
 

--- a/src/packages/react-force-graph-3d/index.d.ts
+++ b/src/packages/react-force-graph-3d/index.d.ts
@@ -21,14 +21,14 @@ export type NodeObject = {
   fz?: number;
 };
 
-type NodeObjectIntersection<NodeType> = NodeType & NodeObject;
+type NodeObjectIntersection<NodeType> = NodeType & NodeObject & { [others: string]: any; };
 
 export type LinkObject<NodeType = {}> = {
   source?: string | number | NodeObjectIntersection<NodeType>;
   target?: string | number | NodeObjectIntersection<NodeType>;
 };
 
-type LinkObjectIntersection<NodeType, LinkType> = LinkType & LinkObject<NodeType>;
+type LinkObjectIntersection<NodeType, LinkType> = LinkType & LinkObject<NodeType> & { [others: string]: any; };
 
 type Accessor<In, Out> = Out | string | ((obj: In) => Out);
 

--- a/src/packages/react-force-graph-3d/index.d.ts
+++ b/src/packages/react-force-graph-3d/index.d.ts
@@ -29,6 +29,8 @@ export type LinkObject<NodeType = {}, LinkType = {}> = LinkType & {
 };
 
 type Accessor<In, Out> = Out | string | ((obj: In) => Out);
+type NodeAccessor<NodeType, T> = Accessor<NodeObject<NodeType>, T>;
+type LinkAccessor<NodeType, LinkType, T> = Accessor<LinkObject<NodeType, LinkType>, T>;
 
 type DagMode = 'td' | 'bu' | 'lr' | 'rl' | 'zout' | 'zin' | 'radialout' | 'radialin';
 
@@ -62,38 +64,38 @@ export interface ForceGraphProps<
 
   // Node styling
   nodeRelSize?: number;
-  nodeVal?: Accessor<NodeObject<NodeType>, number>;
-  nodeLabel?: Accessor<NodeObject<NodeType>, string>;
-  nodeVisibility?: Accessor<NodeObject<NodeType>, boolean>;
-  nodeColor?: Accessor<NodeObject<NodeType>, string>;
-  nodeAutoColorBy?: Accessor<NodeObject<NodeType>, string | null>;
+  nodeVal?: NodeAccessor<NodeType, number>;
+  nodeLabel?: NodeAccessor<NodeType, string>;
+  nodeVisibility?: NodeAccessor<NodeType, boolean>;
+  nodeColor?: NodeAccessor<NodeType, string>;
+  nodeAutoColorBy?: NodeAccessor<NodeType, string | null>;
   nodeOpacity?: number;
   nodeResolution?: number;
-  nodeThreeObject?: Accessor<NodeObject<NodeType>, Object3D>;
-  nodeThreeObjectExtend?: Accessor<NodeObject<NodeType>, boolean>;
+  nodeThreeObject?: NodeAccessor<NodeType, Object3D>;
+  nodeThreeObjectExtend?: NodeAccessor<NodeType, boolean>;
 
   // Link styling
-  linkLabel?: Accessor<LinkObject<NodeType, LinkType>, string>;
-  linkVisibility?: Accessor<LinkObject<NodeType, LinkType>, boolean>;
-  linkColor?: Accessor<LinkObject<NodeType, LinkType>, string>;
-  linkAutoColorBy?: Accessor<LinkObject<NodeType, LinkType>, string | null>;
-  linkWidth?: Accessor<LinkObject<NodeType, LinkType>, number>;
+  linkLabel?: LinkAccessor<NodeType, LinkType, string>;
+  linkVisibility?: LinkAccessor<NodeType, LinkType, boolean>;
+  linkColor?: LinkAccessor<NodeType, LinkType, string>;
+  linkAutoColorBy?: LinkAccessor<NodeType, LinkType, string | null>;
+  linkWidth?: LinkAccessor<NodeType, LinkType, number>;
   linkOpacity?: number;
   linkResolution?: number;
-  linkCurvature?: Accessor<LinkObject<NodeType, LinkType>, number>;
-  linkCurveRotation?: Accessor<LinkObject<NodeType, LinkType>, number>;
-  linkMaterial?: Accessor<LinkObject<NodeType, LinkType>, Material | boolean | null>;
-  linkThreeObject?: Accessor<LinkObject<NodeType, LinkType>, Object3D>;
-  linkThreeObjectExtend?: Accessor<LinkObject<NodeType, LinkType>, boolean>;
+  linkCurvature?: LinkAccessor<NodeType, LinkType, number>;
+  linkCurveRotation?: LinkAccessor<NodeType, LinkType, number>;
+  linkMaterial?: LinkAccessor<NodeType, LinkType, Material | boolean | null>;
+  linkThreeObject?: LinkAccessor<NodeType, LinkType, Object3D>;
+  linkThreeObjectExtend?: LinkAccessor<NodeType, LinkType, boolean>;
   linkPositionUpdate?: LinkPositionUpdateFn | null;
-  linkDirectionalArrowLength?: Accessor<LinkObject<NodeType, LinkType>, number>;
-  linkDirectionalArrowColor?: Accessor<LinkObject<NodeType, LinkType>, string>;
-  linkDirectionalArrowRelPos?: Accessor<LinkObject<NodeType, LinkType>, number>;
+  linkDirectionalArrowLength?: LinkAccessor<NodeType, LinkType, number>;
+  linkDirectionalArrowColor?: LinkAccessor<NodeType, LinkType, string>;
+  linkDirectionalArrowRelPos?: LinkAccessor<NodeType, LinkType, number>;
   linkDirectionalArrowResolution?: number;
-  linkDirectionalParticles?: Accessor<LinkObject<NodeType, LinkType>, number>;
-  linkDirectionalParticleSpeed?: Accessor<LinkObject<NodeType, LinkType>, number>;
-  linkDirectionalParticleWidth?: Accessor<LinkObject<NodeType, LinkType>, number>;
-  linkDirectionalParticleColor?: Accessor<LinkObject<NodeType, LinkType>, string>;
+  linkDirectionalParticles?: LinkAccessor<NodeType, LinkType, number>;
+  linkDirectionalParticleSpeed?: LinkAccessor<NodeType, LinkType, number>;
+  linkDirectionalParticleWidth?: LinkAccessor<NodeType, LinkType, number>;
+  linkDirectionalParticleColor?: LinkAccessor<NodeType, LinkType, string>;
   linkDirectionalParticleResolution?: number;
 
   // Force engine (d3-force) configuration

--- a/src/packages/react-force-graph-3d/index.d.ts
+++ b/src/packages/react-force-graph-3d/index.d.ts
@@ -5,7 +5,7 @@ import { ConfigOptions, ForceGraph3DInstance as ForceGraphKapsuleInstance } from
 
 export interface GraphData<NodeType = {}, LinkType = {}> {
   nodes: NodeObjectIntersection<NodeType>[];
-  links: LinkType[];
+  links: LinkObjectIntersection<NodeType, LinkType>[];
 }
 
 export type NodeObject = {

--- a/src/packages/react-force-graph-3d/index.d.ts
+++ b/src/packages/react-force-graph-3d/index.d.ts
@@ -3,12 +3,12 @@ import { Scene, Camera, WebGLRenderer, Object3D, Material } from 'three';
 import { EffectComposer } from 'three/examples/jsm/postprocessing/EffectComposer.js';
 import { ConfigOptions, ForceGraph3DInstance as ForceGraphKapsuleInstance } from '3d-force-graph';
 
-export interface GraphData {
-  nodes: NodeObject[];
-  links: LinkObject[];
+export interface GraphData<NodeType extends NodeObject, LinkType extends LinkObject<NodeType>> {
+  nodes: NodeType[];
+  links: LinkType[];
 }
 
-export type NodeObject = object & {
+export type NodeObject = {
   id?: string | number;
   x?: number;
   y?: number;
@@ -21,32 +21,33 @@ export type NodeObject = object & {
   fz?: number;
 };
 
-export type LinkObject = object & {
-  source?: string | number | NodeObject;
-  target?: string | number | NodeObject;
+export type LinkObject<NodeType extends NodeObject> = {
+  source?: string | number | NodeType;
+  target?: string | number | NodeType;
 };
 
 type Accessor<In, Out> = Out | string | ((obj: In) => Out);
-type NodeAccessor<T> = Accessor<NodeObject, T>;
-type LinkAccessor<T> = Accessor<LinkObject, T>;
 
 type DagMode = 'td' | 'bu' | 'lr' | 'rl' | 'zout' | 'zin' | 'radialout' | 'radialin';
 
 type ForceEngine = 'd3' | 'ngraph';
 
-interface ForceFn {
+interface ForceFn<NodeType extends NodeObject> {
   (alpha: number): void;
-  initialize?: (nodes: NodeObject[], ...args: any[]) => void;
+  initialize?: (nodes: NodeType[], ...args: any[]) => void;
   [key: string]: any;
 }
 
 type Coords = { x: number; y: number; z: number; }
 
-type LinkPositionUpdateFn = (obj: Object3D, coords: { start: Coords, end: Coords }, link: LinkObject) => void | null | boolean;
+type LinkPositionUpdateFn = <NodeType extends NodeObject, LinkType extends LinkObject<NodeType>>(obj: Object3D, coords: { start: Coords, end: Coords }, link: LinkType) => void | null | boolean;
 
-export interface ForceGraphProps extends ConfigOptions {
+export interface ForceGraphProps<
+  NodeType extends NodeObject,
+  LinkType extends LinkObject<NodeType>
+> extends ConfigOptions {
   // Data input
-  graphData?: GraphData;
+  graphData?: GraphData<NodeType, LinkType>;
   nodeId?: string;
   linkSource?: string;
   linkTarget?: string;
@@ -59,38 +60,38 @@ export interface ForceGraphProps extends ConfigOptions {
 
   // Node styling
   nodeRelSize?: number;
-  nodeVal?: NodeAccessor<number>;
-  nodeLabel?: NodeAccessor<string>;
-  nodeVisibility?: NodeAccessor<boolean>;
-  nodeColor?: NodeAccessor<string>;
-  nodeAutoColorBy?: NodeAccessor<string | null>;
+  nodeVal?: Accessor<NodeType, number>;
+  nodeLabel?: Accessor<NodeType, string>;
+  nodeVisibility?: Accessor<NodeType, boolean>;
+  nodeColor?: Accessor<NodeType, string>;
+  nodeAutoColorBy?: Accessor<NodeType, string | null>;
   nodeOpacity?: number;
   nodeResolution?: number;
-  nodeThreeObject?: NodeAccessor<Object3D>;
-  nodeThreeObjectExtend?: NodeAccessor<boolean>;
+  nodeThreeObject?: Accessor<NodeType, Object3D>;
+  nodeThreeObjectExtend?: Accessor<NodeType, boolean>;
 
   // Link styling
-  linkLabel?: LinkAccessor<string>;
-  linkVisibility?: LinkAccessor<boolean>;
-  linkColor?: LinkAccessor<string>;
-  linkAutoColorBy?: LinkAccessor<string | null>;
-  linkWidth?: LinkAccessor<number>;
+  linkLabel?: Accessor<LinkType, string>;
+  linkVisibility?: Accessor<LinkType, boolean>;
+  linkColor?: Accessor<LinkType, string>;
+  linkAutoColorBy?: Accessor<LinkType, string | null>;
+  linkWidth?: Accessor<LinkType, number>;
   linkOpacity?: number;
   linkResolution?: number;
-  linkCurvature?: LinkAccessor<number>;
-  linkCurveRotation?: LinkAccessor<number>;
-  linkMaterial?: LinkAccessor<Material | boolean | null>;
-  linkThreeObject?: LinkAccessor<Object3D>;
-  linkThreeObjectExtend?: LinkAccessor<boolean>;
+  linkCurvature?: Accessor<LinkType, number>;
+  linkCurveRotation?: Accessor<LinkType, number>;
+  linkMaterial?: Accessor<LinkType, Material | boolean | null>;
+  linkThreeObject?: Accessor<LinkType, Object3D>;
+  linkThreeObjectExtend?: Accessor<LinkType, boolean>;
   linkPositionUpdate?: LinkPositionUpdateFn | null;
-  linkDirectionalArrowLength?: LinkAccessor<number>;
-  linkDirectionalArrowColor?: LinkAccessor<string>;
-  linkDirectionalArrowRelPos?: LinkAccessor<number>;
+  linkDirectionalArrowLength?: Accessor<LinkType, number>;
+  linkDirectionalArrowColor?: Accessor<LinkType, string>;
+  linkDirectionalArrowRelPos?: Accessor<LinkType, number>;
   linkDirectionalArrowResolution?: number;
-  linkDirectionalParticles?: LinkAccessor<number>;
-  linkDirectionalParticleSpeed?: LinkAccessor<number>;
-  linkDirectionalParticleWidth?: LinkAccessor<number>;
-  linkDirectionalParticleColor?: LinkAccessor<string>;
+  linkDirectionalParticles?: Accessor<LinkType, number>;
+  linkDirectionalParticleSpeed?: Accessor<LinkType, number>;
+  linkDirectionalParticleWidth?: Accessor<LinkType, number>;
+  linkDirectionalParticleColor?: Accessor<LinkType, string>;
   linkDirectionalParticleResolution?: number;
 
   // Force engine (d3-force) configuration
@@ -98,7 +99,7 @@ export interface ForceGraphProps extends ConfigOptions {
   numDimensions?: 1 | 2 | 3;
   dagMode?: DagMode;
   dagLevelDistance?: number | null;
-  dagNodeFilter?: (node: NodeObject) => boolean;
+  dagNodeFilter?: (node: NodeType) => boolean;
   onDagError?: ((loopNodeIds: (string | number)[]) => void) | undefined;
   d3AlphaMin?: number;
   d3AlphaDecay?: number;
@@ -111,14 +112,14 @@ export interface ForceGraphProps extends ConfigOptions {
   onEngineStop?: () => void;
 
   // Interaction
-  onNodeClick?: (node: NodeObject, event: MouseEvent) => void;
-  onNodeRightClick?: (node: NodeObject, event: MouseEvent) => void;
-  onNodeHover?: (node: NodeObject | null, previousNode: NodeObject | null) => void;
-  onNodeDrag?: (node: NodeObject, translate: { x: number, y: number }) => void;
-  onNodeDragEnd?: (node: NodeObject, translate: { x: number, y: number }) => void;
-  onLinkClick?: (link: LinkObject, event: MouseEvent) => void;
-  onLinkRightClick?: (link: LinkObject, event: MouseEvent) => void;
-  onLinkHover?: (link: LinkObject | null, previousLink: LinkObject | null) => void;
+  onNodeClick?: (node: NodeType, event: MouseEvent) => void;
+  onNodeRightClick?: (node: NodeType, event: MouseEvent) => void;
+  onNodeHover?: (node: NodeType | null, previousNode: NodeType | null) => void;
+  onNodeDrag?: (node: NodeType, translate: { x: number, y: number }) => void;
+  onNodeDragEnd?: (node: NodeType, translate: { x: number, y: number }) => void;
+  onLinkClick?: (link: LinkType, event: MouseEvent) => void;
+  onLinkRightClick?: (link: LinkType, event: MouseEvent) => void;
+  onLinkHover?: (link: LinkType | null, previousLink: LinkType | null) => void;
   linkHoverPrecision?: number;
   onBackgroundClick?: (event: MouseEvent) => void;
   onBackgroundRightClick?: (event: MouseEvent) => void;
@@ -127,20 +128,23 @@ export interface ForceGraphProps extends ConfigOptions {
   enablePointerInteraction?: boolean;
 }
 
-export interface ForceGraphMethods {
+export interface ForceGraphMethods<
+  NodeType extends NodeObject,
+  LinkType extends LinkObject<NodeType>
+> {
   // Link styling
-  emitParticle(link: LinkObject): ForceGraphKapsuleInstance;
+  emitParticle(link: LinkType): ForceGraphKapsuleInstance;
 
   // Force engine (d3-force) configuration
-  d3Force(forceName: 'link' | 'charge' | 'center' | string): ForceFn | undefined;
-  d3Force(forceName: 'link' | 'charge' | 'center' | string, forceFn: ForceFn): ForceGraphKapsuleInstance;
+  d3Force(forceName: 'link' | 'charge' | 'center' | string): ForceFn<NodeType> | undefined;
+  d3Force(forceName: 'link' | 'charge' | 'center' | string, forceFn: ForceFn<NodeType>): ForceGraphKapsuleInstance;
   d3ReheatSimulation(): ForceGraphKapsuleInstance;
 
   // Render control
   pauseAnimation(): ForceGraphKapsuleInstance;
   resumeAnimation(): ForceGraphKapsuleInstance;
   cameraPosition(position: Partial<Coords>, lookAt?: Coords, transitionMs?: number): ForceGraphKapsuleInstance;
-  zoomToFit(durationMs?: number, padding?: number, nodeFilter?: (node: NodeObject) => boolean): ForceGraphKapsuleInstance;
+  zoomToFit(durationMs?: number, padding?: number, nodeFilter?: (node: NodeType) => boolean): ForceGraphKapsuleInstance;
   postProcessingComposer(): EffectComposer;
   scene(): Scene;
   camera(): Camera;
@@ -149,13 +153,13 @@ export interface ForceGraphMethods {
   refresh(): ForceGraphKapsuleInstance;
 
   // Utility
-  getGraphBbox(nodeFilter?: (node: NodeObject) => boolean): { x: [number, number], y: [number, number], z: [number, number] };
+  getGraphBbox(nodeFilter?: (node: NodeType) => boolean): { x: [number, number], y: [number, number], z: [number, number] };
   screen2GraphCoords(x: number, y: number, distance: number): Coords;
   graph2ScreenCoords(x: number, y: number, z: number): Coords;
 }
 
-type FCwithRef<P = {}, R = {}> = React.FunctionComponent<P & { ref?: React.MutableRefObject<R | undefined> }>;
+type FCwithRef = <NodeType extends NodeObject, LinkType extends LinkObject<NodeType>>(props: ForceGraphProps<NodeType, LinkType> & { ref?: React.MutableRefObject<ForceGraphMethods<NodeType, LinkType> | undefined>; }) => React.ReactElement;
 
-declare const ForceGraph: FCwithRef<ForceGraphProps, ForceGraphMethods>;
+declare const ForceGraph: FCwithRef;
 
 export default ForceGraph;

--- a/src/packages/react-force-graph-ar/index.d.ts
+++ b/src/packages/react-force-graph-ar/index.d.ts
@@ -2,12 +2,12 @@ import * as React from 'react';
 import { Object3D, Material } from 'three';
 import { ConfigOptions, ForceGraphARInstance as ForceGraphKapsuleInstance } from '3d-force-graph-ar';
 
-export interface GraphData {
-  nodes: NodeObject[];
-  links: LinkObject[];
+export interface GraphData<NodeType extends NodeObject, LinkType extends LinkObject<NodeType>> {
+  nodes: NodeType[];
+  links: LinkType[];
 }
 
-export type NodeObject = object & {
+export type NodeObject = {
   id?: string | number;
   x?: number;
   y?: number;
@@ -20,32 +20,33 @@ export type NodeObject = object & {
   fz?: number;
 };
 
-export type LinkObject = object & {
-  source?: string | number | NodeObject;
-  target?: string | number | NodeObject;
+export type LinkObject<NodeType extends NodeObject> = {
+  source?: string | number | NodeType;
+  target?: string | number | NodeType;
 };
 
 type Accessor<In, Out> = Out | string | ((obj: In) => Out);
-type NodeAccessor<T> = Accessor<NodeObject, T>;
-type LinkAccessor<T> = Accessor<LinkObject, T>;
 
 type DagMode = 'td' | 'bu' | 'lr' | 'rl' | 'zout' | 'zin' | 'radialout' | 'radialin';
 
 type ForceEngine = 'd3' | 'ngraph';
 
-interface ForceFn {
+interface ForceFn<NodeType extends NodeObject> {
   (alpha: number): void;
-  initialize?: (nodes: NodeObject[], ...args: any[]) => void;
+  initialize?: (nodes: NodeType[], ...args: any[]) => void;
   [key: string]: any;
 }
 
 type Coords = { x: number; y: number; z: number; }
 
-type LinkPositionUpdateFn = (obj: Object3D, coords: { start: Coords, end: Coords }, link: LinkObject) => void | null | boolean;
+type LinkPositionUpdateFn = <NodeType extends NodeObject, LinkType extends LinkObject<NodeType>>(obj: Object3D, coords: { start: Coords, end: Coords }, link: LinkType) => void | null | boolean;
 
-export interface ForceGraphProps extends ConfigOptions {
+export interface ForceGraphProps<
+  NodeType extends NodeObject,
+  LinkType extends LinkObject<NodeType>
+> extends ConfigOptions {
   // Data input
-  graphData?: GraphData;
+  graphData?: GraphData<NodeType, LinkType>;
   nodeId?: string;
   linkSource?: string;
   linkTarget?: string;
@@ -58,36 +59,36 @@ export interface ForceGraphProps extends ConfigOptions {
 
   // Node styling
   nodeRelSize?: number;
-  nodeVal?: NodeAccessor<number>;
-  nodeVisibility?: NodeAccessor<boolean>;
-  nodeColor?: NodeAccessor<string>;
-  nodeAutoColorBy?: NodeAccessor<string | null>;
+  nodeVal?: Accessor<NodeType, number>;
+  nodeVisibility?: Accessor<NodeType, boolean>;
+  nodeColor?: Accessor<NodeType, string>;
+  nodeAutoColorBy?: Accessor<NodeType, string | null>;
   nodeOpacity?: number;
   nodeResolution?: number;
-  nodeThreeObject?: NodeAccessor<Object3D>;
-  nodeThreeObjectExtend?: NodeAccessor<boolean>;
+  nodeThreeObject?: Accessor<NodeType, Object3D>;
+  nodeThreeObjectExtend?: Accessor<NodeType, boolean>;
 
   // Link styling
-  linkVisibility?: LinkAccessor<boolean>;
-  linkColor?: LinkAccessor<string>;
-  linkAutoColorBy?: LinkAccessor<string | null>;
-  linkWidth?: LinkAccessor<number>;
+  linkVisibility?: Accessor<LinkType, boolean>;
+  linkColor?: Accessor<LinkType, string>;
+  linkAutoColorBy?: Accessor<LinkType, string | null>;
+  linkWidth?: Accessor<LinkType, number>;
   linkOpacity?: number;
   linkResolution?: number;
-  linkCurvature?: LinkAccessor<number>;
-  linkCurveRotation?: LinkAccessor<number>;
-  linkMaterial?: LinkAccessor<Material | boolean | null>;
-  linkThreeObject?: LinkAccessor<Object3D>;
-  linkThreeObjectExtend?: LinkAccessor<boolean>;
+  linkCurvature?: Accessor<LinkType, number>;
+  linkCurveRotation?: Accessor<LinkType, number>;
+  linkMaterial?: Accessor<LinkType, Material | boolean | null>;
+  linkThreeObject?: Accessor<LinkType, Object3D>;
+  linkThreeObjectExtend?: Accessor<LinkType, boolean>;
   linkPositionUpdate?: LinkPositionUpdateFn | null;
-  linkDirectionalArrowLength?: LinkAccessor<number>;
-  linkDirectionalArrowColor?: LinkAccessor<string>;
-  linkDirectionalArrowRelPos?: LinkAccessor<number>;
+  linkDirectionalArrowLength?: Accessor<LinkType, number>;
+  linkDirectionalArrowColor?: Accessor<LinkType, string>;
+  linkDirectionalArrowRelPos?: Accessor<LinkType, number>;
   linkDirectionalArrowResolution?: number;
-  linkDirectionalParticles?: LinkAccessor<number>;
-  linkDirectionalParticleSpeed?: LinkAccessor<number>;
-  linkDirectionalParticleWidth?: LinkAccessor<number>;
-  linkDirectionalParticleColor?: LinkAccessor<string>;
+  linkDirectionalParticles?: Accessor<LinkType, number>;
+  linkDirectionalParticleSpeed?: Accessor<LinkType, number>;
+  linkDirectionalParticleWidth?: Accessor<LinkType, number>;
+  linkDirectionalParticleColor?: Accessor<LinkType, string>;
   linkDirectionalParticleResolution?: number;
 
   // Force engine (d3-force) configuration
@@ -95,7 +96,7 @@ export interface ForceGraphProps extends ConfigOptions {
   numDimensions?: 1 | 2 | 3;
   dagMode?: DagMode;
   dagLevelDistance?: number | null;
-  dagNodeFilter?: (node: NodeObject) => boolean;
+  dagNodeFilter?: (node: NodeType) => boolean;
   onDagError?: ((loopNodeIds: (string | number)[]) => void) | undefined;
   d3AlphaMin?: number;
   d3AlphaDecay?: number;
@@ -108,30 +109,33 @@ export interface ForceGraphProps extends ConfigOptions {
   onEngineStop?: () => void;
 
   // Interaction
-  onNodeHover?: (node: NodeObject | null, previousNode: NodeObject | null) => void;
-  onNodeClick?: (link: LinkObject) => void;
-  onLinkHover?: (link: LinkObject | null, previousLink: LinkObject | null) => void;
-  onLinkClick?: (link: LinkObject) => void;
+  onNodeHover?: (node: NodeType | null, previousNode: NodeType | null) => void;
+  onNodeClick?: (link: LinkType) => void;
+  onLinkHover?: (link: LinkType | null, previousLink: LinkType | null) => void;
+  onLinkClick?: (link: LinkType) => void;
 }
 
-export interface ForceGraphMethods {
+export interface ForceGraphMethods<
+  NodeType extends NodeObject,
+  LinkType extends LinkObject<NodeType>
+> {
   // Link styling
-  emitParticle(link: LinkObject): ForceGraphKapsuleInstance;
+  emitParticle(link: LinkType): ForceGraphKapsuleInstance;
 
   // Force engine (d3-force) configuration
-  d3Force(forceName: 'link' | 'charge' | 'center' | string): ForceFn | undefined;
-  d3Force(forceName: 'link' | 'charge' | 'center' | string, forceFn: ForceFn): ForceGraphKapsuleInstance;
+  d3Force(forceName: 'link' | 'charge' | 'center' | string): ForceFn<NodeType> | undefined;
+  d3Force(forceName: 'link' | 'charge' | 'center' | string, forceFn: ForceFn<NodeType>): ForceGraphKapsuleInstance;
   d3ReheatSimulation(): ForceGraphKapsuleInstance;
 
   // Render control
   refresh(): ForceGraphKapsuleInstance;
 
   // Utility
-  getGraphBbox(nodeFilter?: (node: NodeObject) => boolean): { x: [number, number], y: [number, number], z: [number, number] };
+  getGraphBbox(nodeFilter?: (node: NodeType) => boolean): { x: [number, number], y: [number, number], z: [number, number] };
 }
 
-type FCwithRef<P = {}, R = {}> = React.FunctionComponent<P & { ref?: React.MutableRefObject<R | undefined> }>;
+type FCwithRef = <NodeType extends NodeObject, LinkType extends LinkObject<NodeType>>(props: ForceGraphProps<NodeType, LinkType> & { ref?: React.MutableRefObject<ForceGraphMethods<NodeType, LinkType> | undefined>; }) => React.ReactElement;
 
-declare const ForceGraph: FCwithRef<ForceGraphProps, ForceGraphMethods>;
+declare const ForceGraph: FCwithRef;
 
 export default ForceGraph;

--- a/src/packages/react-force-graph-ar/index.d.ts
+++ b/src/packages/react-force-graph-ar/index.d.ts
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { Object3D, Material } from 'three';
 import { ConfigOptions, ForceGraphARInstance as ForceGraphKapsuleInstance } from '3d-force-graph-ar';
 
-export interface GraphData<NodeType, LinkType> {
+export interface GraphData<NodeType = {}, LinkType = {}> {
   nodes: NodeObjectIntersection<NodeType>[];
   links: LinkObjectIntersection<NodeType, LinkType>[];
 }
@@ -27,7 +27,7 @@ export type LinkObject<NodeType> = {
   target?: string | number | NodeObjectIntersection<NodeType>;
 };
 
-type LinkObjectIntersection<NodeType, LinkType> = LinkType & LinkObject<NodeType>;
+type LinkObjectIntersection<NodeType = {}, LinkType = {}> = LinkType & LinkObject<NodeType>;
 
 type Accessor<In, Out> = Out | string | ((obj: In) => Out);
 
@@ -35,7 +35,7 @@ type DagMode = 'td' | 'bu' | 'lr' | 'rl' | 'zout' | 'zin' | 'radialout' | 'radia
 
 type ForceEngine = 'd3' | 'ngraph';
 
-interface ForceFn<NodeType> {
+interface ForceFn<NodeType = {}> {
   (alpha: number): void;
   initialize?: (nodes: NodeObjectIntersection<NodeType>[], ...args: any[]) => void;
   [key: string]: any;
@@ -43,11 +43,11 @@ interface ForceFn<NodeType> {
 
 type Coords = { x: number; y: number; z: number; }
 
-type LinkPositionUpdateFn = <NodeType, LinkType>(obj: Object3D, coords: { start: Coords, end: Coords }, link: LinkObjectIntersection<NodeType, LinkType>) => void | null | boolean;
+type LinkPositionUpdateFn = <NodeType = {}, LinkType = {}>(obj: Object3D, coords: { start: Coords, end: Coords }, link: LinkObjectIntersection<NodeType, LinkType>) => void | null | boolean;
 
 export interface ForceGraphProps<
-  NodeType,
-  LinkType
+  NodeType = {},
+  LinkType = {}
 > extends ConfigOptions {
   // Data input
   graphData?: GraphData<NodeObjectIntersection<NodeType>, LinkObjectIntersection<NodeType, LinkType>>;
@@ -120,8 +120,8 @@ export interface ForceGraphProps<
 }
 
 export interface ForceGraphMethods<
-  NodeType,
-  LinkType
+  NodeType = {},
+  LinkType = {}
 > {
   // Link styling
   emitParticle(link: LinkObjectIntersection<NodeType, LinkType>): ForceGraphKapsuleInstance;
@@ -138,7 +138,7 @@ export interface ForceGraphMethods<
   getGraphBbox(nodeFilter?: (node: NodeObjectIntersection<NodeType>) => boolean): { x: [number, number], y: [number, number], z: [number, number] };
 }
 
-type FCwithRef = <NodeType, LinkType>(props: ForceGraphProps<NodeObjectIntersection<NodeType>, LinkObjectIntersection<NodeType, LinkType>> & { ref?: React.MutableRefObject<ForceGraphMethods<NodeObjectIntersection<NodeType>, LinkObjectIntersection<NodeType, LinkType>> | undefined>; }) => React.ReactElement;
+type FCwithRef = <NodeType = {}, LinkType = {}>(props: ForceGraphProps<NodeObjectIntersection<NodeType>, LinkObjectIntersection<NodeType, LinkType>> & { ref?: React.MutableRefObject<ForceGraphMethods<NodeObjectIntersection<NodeType>, LinkObjectIntersection<NodeType, LinkType>> | undefined>; }) => React.ReactElement;
 
 declare const ForceGraph: FCwithRef;
 

--- a/src/packages/react-force-graph-ar/index.d.ts
+++ b/src/packages/react-force-graph-ar/index.d.ts
@@ -20,14 +20,14 @@ export type NodeObject = {
   fz?: number;
 };
 
-type NodeObjectIntersection<NodeType> = NodeType & NodeObject;
+type NodeObjectIntersection<NodeType> = NodeType & NodeObject & { [others: string]: any; };
 
 export type LinkObject<NodeType> = {
   source?: string | number | NodeObjectIntersection<NodeType>;
   target?: string | number | NodeObjectIntersection<NodeType>;
 };
 
-type LinkObjectIntersection<NodeType = {}, LinkType = {}> = LinkType & LinkObject<NodeType>;
+type LinkObjectIntersection<NodeType = {}, LinkType = {}> = LinkType & LinkObject<NodeType> & { [others: string]: any; };
 
 type Accessor<In, Out> = Out | string | ((obj: In) => Out);
 

--- a/src/packages/react-force-graph-ar/index.d.ts
+++ b/src/packages/react-force-graph-ar/index.d.ts
@@ -2,9 +2,9 @@ import * as React from 'react';
 import { Object3D, Material } from 'three';
 import { ConfigOptions, ForceGraphARInstance as ForceGraphKapsuleInstance } from '3d-force-graph-ar';
 
-export interface GraphData<NodeType extends NodeObject, LinkType extends LinkObject<NodeType>> {
-  nodes: NodeType[];
-  links: LinkType[];
+export interface GraphData<NodeType, LinkType> {
+  nodes: NodeObjectIntersection<NodeType>[];
+  links: LinkObjectIntersection<NodeType, LinkType>[];
 }
 
 export type NodeObject = {
@@ -20,10 +20,14 @@ export type NodeObject = {
   fz?: number;
 };
 
-export type LinkObject<NodeType extends NodeObject> = {
-  source?: string | number | NodeType;
-  target?: string | number | NodeType;
+type NodeObjectIntersection<NodeType> = NodeType & NodeObject;
+
+export type LinkObject<NodeType> = {
+  source?: string | number | NodeObjectIntersection<NodeType>;
+  target?: string | number | NodeObjectIntersection<NodeType>;
 };
+
+type LinkObjectIntersection<NodeType, LinkType> = LinkType & LinkObject<NodeType>;
 
 type Accessor<In, Out> = Out | string | ((obj: In) => Out);
 
@@ -31,22 +35,22 @@ type DagMode = 'td' | 'bu' | 'lr' | 'rl' | 'zout' | 'zin' | 'radialout' | 'radia
 
 type ForceEngine = 'd3' | 'ngraph';
 
-interface ForceFn<NodeType extends NodeObject> {
+interface ForceFn<NodeType> {
   (alpha: number): void;
-  initialize?: (nodes: NodeType[], ...args: any[]) => void;
+  initialize?: (nodes: NodeObjectIntersection<NodeType>[], ...args: any[]) => void;
   [key: string]: any;
 }
 
 type Coords = { x: number; y: number; z: number; }
 
-type LinkPositionUpdateFn = <NodeType extends NodeObject, LinkType extends LinkObject<NodeType>>(obj: Object3D, coords: { start: Coords, end: Coords }, link: LinkType) => void | null | boolean;
+type LinkPositionUpdateFn = <NodeType, LinkType>(obj: Object3D, coords: { start: Coords, end: Coords }, link: LinkObjectIntersection<NodeType, LinkType>) => void | null | boolean;
 
 export interface ForceGraphProps<
-  NodeType extends NodeObject,
-  LinkType extends LinkObject<NodeType>
+  NodeType,
+  LinkType
 > extends ConfigOptions {
   // Data input
-  graphData?: GraphData<NodeType, LinkType>;
+  graphData?: GraphData<NodeObjectIntersection<NodeType>, LinkObjectIntersection<NodeType, LinkType>>;
   nodeId?: string;
   linkSource?: string;
   linkTarget?: string;
@@ -59,36 +63,36 @@ export interface ForceGraphProps<
 
   // Node styling
   nodeRelSize?: number;
-  nodeVal?: Accessor<NodeType, number>;
-  nodeVisibility?: Accessor<NodeType, boolean>;
-  nodeColor?: Accessor<NodeType, string>;
-  nodeAutoColorBy?: Accessor<NodeType, string | null>;
+  nodeVal?: Accessor<NodeObjectIntersection<NodeType>, number>;
+  nodeVisibility?: Accessor<NodeObjectIntersection<NodeType>, boolean>;
+  nodeColor?: Accessor<NodeObjectIntersection<NodeType>, string>;
+  nodeAutoColorBy?: Accessor<NodeObjectIntersection<NodeType>, string | null>;
   nodeOpacity?: number;
   nodeResolution?: number;
-  nodeThreeObject?: Accessor<NodeType, Object3D>;
-  nodeThreeObjectExtend?: Accessor<NodeType, boolean>;
+  nodeThreeObject?: Accessor<NodeObjectIntersection<NodeType>, Object3D>;
+  nodeThreeObjectExtend?: Accessor<NodeObjectIntersection<NodeType>, boolean>;
 
   // Link styling
-  linkVisibility?: Accessor<LinkType, boolean>;
-  linkColor?: Accessor<LinkType, string>;
-  linkAutoColorBy?: Accessor<LinkType, string | null>;
-  linkWidth?: Accessor<LinkType, number>;
+  linkVisibility?: Accessor<LinkObjectIntersection<NodeType, LinkType>, boolean>;
+  linkColor?: Accessor<LinkObjectIntersection<NodeType, LinkType>, string>;
+  linkAutoColorBy?: Accessor<LinkObjectIntersection<NodeType, LinkType>, string | null>;
+  linkWidth?: Accessor<LinkObjectIntersection<NodeType, LinkType>, number>;
   linkOpacity?: number;
   linkResolution?: number;
-  linkCurvature?: Accessor<LinkType, number>;
-  linkCurveRotation?: Accessor<LinkType, number>;
-  linkMaterial?: Accessor<LinkType, Material | boolean | null>;
-  linkThreeObject?: Accessor<LinkType, Object3D>;
-  linkThreeObjectExtend?: Accessor<LinkType, boolean>;
+  linkCurvature?: Accessor<LinkObjectIntersection<NodeType, LinkType>, number>;
+  linkCurveRotation?: Accessor<LinkObjectIntersection<NodeType, LinkType>, number>;
+  linkMaterial?: Accessor<LinkObjectIntersection<NodeType, LinkType>, Material | boolean | null>;
+  linkThreeObject?: Accessor<LinkObjectIntersection<NodeType, LinkType>, Object3D>;
+  linkThreeObjectExtend?: Accessor<LinkObjectIntersection<NodeType, LinkType>, boolean>;
   linkPositionUpdate?: LinkPositionUpdateFn | null;
-  linkDirectionalArrowLength?: Accessor<LinkType, number>;
-  linkDirectionalArrowColor?: Accessor<LinkType, string>;
-  linkDirectionalArrowRelPos?: Accessor<LinkType, number>;
+  linkDirectionalArrowLength?: Accessor<LinkObjectIntersection<NodeType, LinkType>, number>;
+  linkDirectionalArrowColor?: Accessor<LinkObjectIntersection<NodeType, LinkType>, string>;
+  linkDirectionalArrowRelPos?: Accessor<LinkObjectIntersection<NodeType, LinkType>, number>;
   linkDirectionalArrowResolution?: number;
-  linkDirectionalParticles?: Accessor<LinkType, number>;
-  linkDirectionalParticleSpeed?: Accessor<LinkType, number>;
-  linkDirectionalParticleWidth?: Accessor<LinkType, number>;
-  linkDirectionalParticleColor?: Accessor<LinkType, string>;
+  linkDirectionalParticles?: Accessor<LinkObjectIntersection<NodeType, LinkType>, number>;
+  linkDirectionalParticleSpeed?: Accessor<LinkObjectIntersection<NodeType, LinkType>, number>;
+  linkDirectionalParticleWidth?: Accessor<LinkObjectIntersection<NodeType, LinkType>, number>;
+  linkDirectionalParticleColor?: Accessor<LinkObjectIntersection<NodeType, LinkType>, string>;
   linkDirectionalParticleResolution?: number;
 
   // Force engine (d3-force) configuration
@@ -96,7 +100,7 @@ export interface ForceGraphProps<
   numDimensions?: 1 | 2 | 3;
   dagMode?: DagMode;
   dagLevelDistance?: number | null;
-  dagNodeFilter?: (node: NodeType) => boolean;
+  dagNodeFilter?: (node: NodeObjectIntersection<NodeType>) => boolean;
   onDagError?: ((loopNodeIds: (string | number)[]) => void) | undefined;
   d3AlphaMin?: number;
   d3AlphaDecay?: number;
@@ -109,32 +113,32 @@ export interface ForceGraphProps<
   onEngineStop?: () => void;
 
   // Interaction
-  onNodeHover?: (node: NodeType | null, previousNode: NodeType | null) => void;
-  onNodeClick?: (link: LinkType) => void;
-  onLinkHover?: (link: LinkType | null, previousLink: LinkType | null) => void;
-  onLinkClick?: (link: LinkType) => void;
+  onNodeHover?: (node: NodeObjectIntersection<NodeType> | null, previousNode: NodeObjectIntersection<NodeType> | null) => void;
+  onNodeClick?: (link: LinkObjectIntersection<NodeType, LinkType>) => void;
+  onLinkHover?: (link: LinkObjectIntersection<NodeType, LinkType> | null, previousLink: LinkObjectIntersection<NodeType, LinkType> | null) => void;
+  onLinkClick?: (link: LinkObjectIntersection<NodeType, LinkType>) => void;
 }
 
 export interface ForceGraphMethods<
-  NodeType extends NodeObject,
-  LinkType extends LinkObject<NodeType>
+  NodeType,
+  LinkType
 > {
   // Link styling
-  emitParticle(link: LinkType): ForceGraphKapsuleInstance;
+  emitParticle(link: LinkObjectIntersection<NodeType, LinkType>): ForceGraphKapsuleInstance;
 
   // Force engine (d3-force) configuration
-  d3Force(forceName: 'link' | 'charge' | 'center' | string): ForceFn<NodeType> | undefined;
-  d3Force(forceName: 'link' | 'charge' | 'center' | string, forceFn: ForceFn<NodeType>): ForceGraphKapsuleInstance;
+  d3Force(forceName: 'link' | 'charge' | 'center' | string): ForceFn<NodeObjectIntersection<NodeType>> | undefined;
+  d3Force(forceName: 'link' | 'charge' | 'center' | string, forceFn: ForceFn<NodeObjectIntersection<NodeType>>): ForceGraphKapsuleInstance;
   d3ReheatSimulation(): ForceGraphKapsuleInstance;
 
   // Render control
   refresh(): ForceGraphKapsuleInstance;
 
   // Utility
-  getGraphBbox(nodeFilter?: (node: NodeType) => boolean): { x: [number, number], y: [number, number], z: [number, number] };
+  getGraphBbox(nodeFilter?: (node: NodeObjectIntersection<NodeType>) => boolean): { x: [number, number], y: [number, number], z: [number, number] };
 }
 
-type FCwithRef = <NodeType extends NodeObject, LinkType extends LinkObject<NodeType>>(props: ForceGraphProps<NodeType, LinkType> & { ref?: React.MutableRefObject<ForceGraphMethods<NodeType, LinkType> | undefined>; }) => React.ReactElement;
+type FCwithRef = <NodeType, LinkType>(props: ForceGraphProps<NodeObjectIntersection<NodeType>, LinkObjectIntersection<NodeType, LinkType>> & { ref?: React.MutableRefObject<ForceGraphMethods<NodeObjectIntersection<NodeType>, LinkObjectIntersection<NodeType, LinkType>> | undefined>; }) => React.ReactElement;
 
 declare const ForceGraph: FCwithRef;
 

--- a/src/packages/react-force-graph-ar/index.d.ts
+++ b/src/packages/react-force-graph-ar/index.d.ts
@@ -28,6 +28,8 @@ export type LinkObject<NodeType = {}, LinkType = {}> = LinkType & {
 };
 
 type Accessor<In, Out> = Out | string | ((obj: In) => Out);
+type NodeAccessor<NodeType, T> = Accessor<NodeObject<NodeType>, T>;
+type LinkAccessor<NodeType, LinkType, T> = Accessor<LinkObject<NodeType, LinkType>, T>;
 
 type DagMode = 'td' | 'bu' | 'lr' | 'rl' | 'zout' | 'zin' | 'radialout' | 'radialin';
 
@@ -61,36 +63,36 @@ export interface ForceGraphProps<
 
   // Node styling
   nodeRelSize?: number;
-  nodeVal?: Accessor<NodeObject<NodeType>, number>;
-  nodeVisibility?: Accessor<NodeObject<NodeType>, boolean>;
-  nodeColor?: Accessor<NodeObject<NodeType>, string>;
-  nodeAutoColorBy?: Accessor<NodeObject<NodeType>, string | null>;
+  nodeVal?: NodeAccessor<NodeType, number>;
+  nodeVisibility?: NodeAccessor<NodeType, boolean>;
+  nodeColor?: NodeAccessor<NodeType, string>;
+  nodeAutoColorBy?: NodeAccessor<NodeType, string | null>;
   nodeOpacity?: number;
   nodeResolution?: number;
-  nodeThreeObject?: Accessor<NodeObject<NodeType>, Object3D>;
-  nodeThreeObjectExtend?: Accessor<NodeObject<NodeType>, boolean>;
+  nodeThreeObject?: NodeAccessor<NodeType, Object3D>;
+  nodeThreeObjectExtend?: NodeAccessor<NodeType, boolean>;
 
   // Link styling
-  linkVisibility?: Accessor<LinkObject<NodeType, LinkType>, boolean>;
-  linkColor?: Accessor<LinkObject<NodeType, LinkType>, string>;
-  linkAutoColorBy?: Accessor<LinkObject<NodeType, LinkType>, string | null>;
-  linkWidth?: Accessor<LinkObject<NodeType, LinkType>, number>;
+  linkVisibility?: LinkAccessor<NodeType, LinkType, boolean>;
+  linkColor?: LinkAccessor<NodeType, LinkType, string>;
+  linkAutoColorBy?: LinkAccessor<NodeType, LinkType, string | null>;
+  linkWidth?: LinkAccessor<NodeType, LinkType, number>;
   linkOpacity?: number;
   linkResolution?: number;
-  linkCurvature?: Accessor<LinkObject<NodeType, LinkType>, number>;
-  linkCurveRotation?: Accessor<LinkObject<NodeType, LinkType>, number>;
-  linkMaterial?: Accessor<LinkObject<NodeType, LinkType>, Material | boolean | null>;
-  linkThreeObject?: Accessor<LinkObject<NodeType, LinkType>, Object3D>;
-  linkThreeObjectExtend?: Accessor<LinkObject<NodeType, LinkType>, boolean>;
+  linkCurvature?: LinkAccessor<NodeType, LinkType, number>;
+  linkCurveRotation?: LinkAccessor<NodeType, LinkType, number>;
+  linkMaterial?: LinkAccessor<NodeType, LinkType, Material | boolean | null>;
+  linkThreeObject?: LinkAccessor<NodeType, LinkType, Object3D>;
+  linkThreeObjectExtend?: LinkAccessor<NodeType, LinkType, boolean>;
   linkPositionUpdate?: LinkPositionUpdateFn | null;
-  linkDirectionalArrowLength?: Accessor<LinkObject<NodeType, LinkType>, number>;
-  linkDirectionalArrowColor?: Accessor<LinkObject<NodeType, LinkType>, string>;
-  linkDirectionalArrowRelPos?: Accessor<LinkObject<NodeType, LinkType>, number>;
+  linkDirectionalArrowLength?: LinkAccessor<NodeType, LinkType, number>;
+  linkDirectionalArrowColor?: LinkAccessor<NodeType, LinkType, string>;
+  linkDirectionalArrowRelPos?: LinkAccessor<NodeType, LinkType, number>;
   linkDirectionalArrowResolution?: number;
-  linkDirectionalParticles?: Accessor<LinkObject<NodeType, LinkType>, number>;
-  linkDirectionalParticleSpeed?: Accessor<LinkObject<NodeType, LinkType>, number>;
-  linkDirectionalParticleWidth?: Accessor<LinkObject<NodeType, LinkType>, number>;
-  linkDirectionalParticleColor?: Accessor<LinkObject<NodeType, LinkType>, string>;
+  linkDirectionalParticles?: LinkAccessor<NodeType, LinkType, number>;
+  linkDirectionalParticleSpeed?: LinkAccessor<NodeType, LinkType, number>;
+  linkDirectionalParticleWidth?: LinkAccessor<NodeType, LinkType, number>;
+  linkDirectionalParticleColor?: LinkAccessor<NodeType, LinkType, string>;
   linkDirectionalParticleResolution?: number;
 
   // Force engine (d3-force) configuration

--- a/src/packages/react-force-graph-ar/index.d.ts
+++ b/src/packages/react-force-graph-ar/index.d.ts
@@ -3,11 +3,11 @@ import { Object3D, Material } from 'three';
 import { ConfigOptions, ForceGraphARInstance as ForceGraphKapsuleInstance } from '3d-force-graph-ar';
 
 export interface GraphData<NodeType = {}, LinkType = {}> {
-  nodes: NodeObjectIntersection<NodeType>[];
-  links: LinkObjectIntersection<NodeType, LinkType>[];
+  nodes: NodeObject<NodeType>[];
+  links: LinkObject<NodeType, LinkType>[];
 }
 
-export type NodeObject = {
+export type NodeObject<NodeType = {}> = NodeType & {
   id?: string | number;
   x?: number;
   y?: number;
@@ -18,16 +18,14 @@ export type NodeObject = {
   fx?: number;
   fy?: number;
   fz?: number;
+  [others: string]: any;
 };
 
-type NodeObjectIntersection<NodeType> = NodeType & NodeObject & { [others: string]: any; };
-
-export type LinkObject<NodeType> = {
-  source?: string | number | NodeObjectIntersection<NodeType>;
-  target?: string | number | NodeObjectIntersection<NodeType>;
+export type LinkObject<NodeType = {}, LinkType = {}> = LinkType & {
+  source?: string | number | NodeObject<NodeType>;
+  target?: string | number | NodeObject<NodeType>;
+  [others: string]: any;
 };
-
-type LinkObjectIntersection<NodeType = {}, LinkType = {}> = LinkType & LinkObject<NodeType> & { [others: string]: any; };
 
 type Accessor<In, Out> = Out | string | ((obj: In) => Out);
 
@@ -37,20 +35,20 @@ type ForceEngine = 'd3' | 'ngraph';
 
 interface ForceFn<NodeType = {}> {
   (alpha: number): void;
-  initialize?: (nodes: NodeObjectIntersection<NodeType>[], ...args: any[]) => void;
+  initialize?: (nodes: NodeObject<NodeType>[], ...args: any[]) => void;
   [key: string]: any;
 }
 
 type Coords = { x: number; y: number; z: number; }
 
-type LinkPositionUpdateFn = <NodeType = {}, LinkType = {}>(obj: Object3D, coords: { start: Coords, end: Coords }, link: LinkObjectIntersection<NodeType, LinkType>) => void | null | boolean;
+type LinkPositionUpdateFn = <NodeType = {}, LinkType = {}>(obj: Object3D, coords: { start: Coords, end: Coords }, link: LinkObject<NodeType, LinkType>) => void | null | boolean;
 
 export interface ForceGraphProps<
   NodeType = {},
   LinkType = {}
 > extends ConfigOptions {
   // Data input
-  graphData?: GraphData<NodeObjectIntersection<NodeType>, LinkObjectIntersection<NodeType, LinkType>>;
+  graphData?: GraphData<NodeObject<NodeType>, LinkObject<NodeType, LinkType>>;
   nodeId?: string;
   linkSource?: string;
   linkTarget?: string;
@@ -63,36 +61,36 @@ export interface ForceGraphProps<
 
   // Node styling
   nodeRelSize?: number;
-  nodeVal?: Accessor<NodeObjectIntersection<NodeType>, number>;
-  nodeVisibility?: Accessor<NodeObjectIntersection<NodeType>, boolean>;
-  nodeColor?: Accessor<NodeObjectIntersection<NodeType>, string>;
-  nodeAutoColorBy?: Accessor<NodeObjectIntersection<NodeType>, string | null>;
+  nodeVal?: Accessor<NodeObject<NodeType>, number>;
+  nodeVisibility?: Accessor<NodeObject<NodeType>, boolean>;
+  nodeColor?: Accessor<NodeObject<NodeType>, string>;
+  nodeAutoColorBy?: Accessor<NodeObject<NodeType>, string | null>;
   nodeOpacity?: number;
   nodeResolution?: number;
-  nodeThreeObject?: Accessor<NodeObjectIntersection<NodeType>, Object3D>;
-  nodeThreeObjectExtend?: Accessor<NodeObjectIntersection<NodeType>, boolean>;
+  nodeThreeObject?: Accessor<NodeObject<NodeType>, Object3D>;
+  nodeThreeObjectExtend?: Accessor<NodeObject<NodeType>, boolean>;
 
   // Link styling
-  linkVisibility?: Accessor<LinkObjectIntersection<NodeType, LinkType>, boolean>;
-  linkColor?: Accessor<LinkObjectIntersection<NodeType, LinkType>, string>;
-  linkAutoColorBy?: Accessor<LinkObjectIntersection<NodeType, LinkType>, string | null>;
-  linkWidth?: Accessor<LinkObjectIntersection<NodeType, LinkType>, number>;
+  linkVisibility?: Accessor<LinkObject<NodeType, LinkType>, boolean>;
+  linkColor?: Accessor<LinkObject<NodeType, LinkType>, string>;
+  linkAutoColorBy?: Accessor<LinkObject<NodeType, LinkType>, string | null>;
+  linkWidth?: Accessor<LinkObject<NodeType, LinkType>, number>;
   linkOpacity?: number;
   linkResolution?: number;
-  linkCurvature?: Accessor<LinkObjectIntersection<NodeType, LinkType>, number>;
-  linkCurveRotation?: Accessor<LinkObjectIntersection<NodeType, LinkType>, number>;
-  linkMaterial?: Accessor<LinkObjectIntersection<NodeType, LinkType>, Material | boolean | null>;
-  linkThreeObject?: Accessor<LinkObjectIntersection<NodeType, LinkType>, Object3D>;
-  linkThreeObjectExtend?: Accessor<LinkObjectIntersection<NodeType, LinkType>, boolean>;
+  linkCurvature?: Accessor<LinkObject<NodeType, LinkType>, number>;
+  linkCurveRotation?: Accessor<LinkObject<NodeType, LinkType>, number>;
+  linkMaterial?: Accessor<LinkObject<NodeType, LinkType>, Material | boolean | null>;
+  linkThreeObject?: Accessor<LinkObject<NodeType, LinkType>, Object3D>;
+  linkThreeObjectExtend?: Accessor<LinkObject<NodeType, LinkType>, boolean>;
   linkPositionUpdate?: LinkPositionUpdateFn | null;
-  linkDirectionalArrowLength?: Accessor<LinkObjectIntersection<NodeType, LinkType>, number>;
-  linkDirectionalArrowColor?: Accessor<LinkObjectIntersection<NodeType, LinkType>, string>;
-  linkDirectionalArrowRelPos?: Accessor<LinkObjectIntersection<NodeType, LinkType>, number>;
+  linkDirectionalArrowLength?: Accessor<LinkObject<NodeType, LinkType>, number>;
+  linkDirectionalArrowColor?: Accessor<LinkObject<NodeType, LinkType>, string>;
+  linkDirectionalArrowRelPos?: Accessor<LinkObject<NodeType, LinkType>, number>;
   linkDirectionalArrowResolution?: number;
-  linkDirectionalParticles?: Accessor<LinkObjectIntersection<NodeType, LinkType>, number>;
-  linkDirectionalParticleSpeed?: Accessor<LinkObjectIntersection<NodeType, LinkType>, number>;
-  linkDirectionalParticleWidth?: Accessor<LinkObjectIntersection<NodeType, LinkType>, number>;
-  linkDirectionalParticleColor?: Accessor<LinkObjectIntersection<NodeType, LinkType>, string>;
+  linkDirectionalParticles?: Accessor<LinkObject<NodeType, LinkType>, number>;
+  linkDirectionalParticleSpeed?: Accessor<LinkObject<NodeType, LinkType>, number>;
+  linkDirectionalParticleWidth?: Accessor<LinkObject<NodeType, LinkType>, number>;
+  linkDirectionalParticleColor?: Accessor<LinkObject<NodeType, LinkType>, string>;
   linkDirectionalParticleResolution?: number;
 
   // Force engine (d3-force) configuration
@@ -100,7 +98,7 @@ export interface ForceGraphProps<
   numDimensions?: 1 | 2 | 3;
   dagMode?: DagMode;
   dagLevelDistance?: number | null;
-  dagNodeFilter?: (node: NodeObjectIntersection<NodeType>) => boolean;
+  dagNodeFilter?: (node: NodeObject<NodeType>) => boolean;
   onDagError?: ((loopNodeIds: (string | number)[]) => void) | undefined;
   d3AlphaMin?: number;
   d3AlphaDecay?: number;
@@ -113,10 +111,10 @@ export interface ForceGraphProps<
   onEngineStop?: () => void;
 
   // Interaction
-  onNodeHover?: (node: NodeObjectIntersection<NodeType> | null, previousNode: NodeObjectIntersection<NodeType> | null) => void;
-  onNodeClick?: (link: LinkObjectIntersection<NodeType, LinkType>) => void;
-  onLinkHover?: (link: LinkObjectIntersection<NodeType, LinkType> | null, previousLink: LinkObjectIntersection<NodeType, LinkType> | null) => void;
-  onLinkClick?: (link: LinkObjectIntersection<NodeType, LinkType>) => void;
+  onNodeHover?: (node: NodeObject<NodeType> | null, previousNode: NodeObject<NodeType> | null) => void;
+  onNodeClick?: (link: LinkObject<NodeType, LinkType>) => void;
+  onLinkHover?: (link: LinkObject<NodeType, LinkType> | null, previousLink: LinkObject<NodeType, LinkType> | null) => void;
+  onLinkClick?: (link: LinkObject<NodeType, LinkType>) => void;
 }
 
 export interface ForceGraphMethods<
@@ -124,21 +122,21 @@ export interface ForceGraphMethods<
   LinkType = {}
 > {
   // Link styling
-  emitParticle(link: LinkObjectIntersection<NodeType, LinkType>): ForceGraphKapsuleInstance;
+  emitParticle(link: LinkObject<NodeType, LinkType>): ForceGraphKapsuleInstance;
 
   // Force engine (d3-force) configuration
-  d3Force(forceName: 'link' | 'charge' | 'center' | string): ForceFn<NodeObjectIntersection<NodeType>> | undefined;
-  d3Force(forceName: 'link' | 'charge' | 'center' | string, forceFn: ForceFn<NodeObjectIntersection<NodeType>>): ForceGraphKapsuleInstance;
+  d3Force(forceName: 'link' | 'charge' | 'center' | string): ForceFn<NodeObject<NodeType>> | undefined;
+  d3Force(forceName: 'link' | 'charge' | 'center' | string, forceFn: ForceFn<NodeObject<NodeType>>): ForceGraphKapsuleInstance;
   d3ReheatSimulation(): ForceGraphKapsuleInstance;
 
   // Render control
   refresh(): ForceGraphKapsuleInstance;
 
   // Utility
-  getGraphBbox(nodeFilter?: (node: NodeObjectIntersection<NodeType>) => boolean): { x: [number, number], y: [number, number], z: [number, number] };
+  getGraphBbox(nodeFilter?: (node: NodeObject<NodeType>) => boolean): { x: [number, number], y: [number, number], z: [number, number] };
 }
 
-type FCwithRef = <NodeType = {}, LinkType = {}>(props: ForceGraphProps<NodeObjectIntersection<NodeType>, LinkObjectIntersection<NodeType, LinkType>> & { ref?: React.MutableRefObject<ForceGraphMethods<NodeObjectIntersection<NodeType>, LinkObjectIntersection<NodeType, LinkType>> | undefined>; }) => React.ReactElement;
+type FCwithRef = <NodeType = {}, LinkType = {}>(props: ForceGraphProps<NodeObject<NodeType>, LinkObject<NodeType, LinkType>> & { ref?: React.MutableRefObject<ForceGraphMethods<NodeObject<NodeType>, LinkObject<NodeType, LinkType>> | undefined>; }) => React.ReactElement;
 
 declare const ForceGraph: FCwithRef;
 

--- a/src/packages/react-force-graph-vr/index.d.ts
+++ b/src/packages/react-force-graph-vr/index.d.ts
@@ -3,11 +3,11 @@ import { Object3D, Material } from 'three';
 import { ConfigOptions, ForceGraphVRInstance as ForceGraphKapsuleInstance } from '3d-force-graph-vr';
 
 export interface GraphData<NodeType = {}, LinkType = {}> {
-  nodes: NodeObjectIntersection<NodeType>[];
-  links: LinkObjectIntersection<NodeType, LinkType>[];
+  nodes: NodeObject<NodeType>[];
+  links: LinkObject<NodeType, LinkType>[];
 }
 
-export type NodeObject = {
+export type NodeObject<NodeType = {}> = NodeType & {
   id?: string | number;
   x?: number;
   y?: number;
@@ -18,16 +18,14 @@ export type NodeObject = {
   fx?: number;
   fy?: number;
   fz?: number;
+  [others: string]: any;
 };
 
-type NodeObjectIntersection<NodeType> = NodeType & NodeObject & { [others: string]: any; };
-
-export type LinkObject<NodeType> = {
-  source?: string | number | NodeObjectIntersection<NodeType>;
-  target?: string | number | NodeObjectIntersection<NodeType>;
+export type LinkObject<NodeType = {}, LinkType = {}> = LinkType & {
+  source?: string | number | NodeObject<NodeType>;
+  target?: string | number | NodeObject<NodeType>;
+  [others: string]: any;
 };
-
-type LinkObjectIntersection<NodeType = {}, LinkType = {}> = LinkType & LinkObject<NodeType> & { [others: string]: any; };
 
 type Accessor<In, Out> = Out | string | ((obj: In) => Out);
 
@@ -37,20 +35,20 @@ type ForceEngine = 'd3' | 'ngraph';
 
 interface ForceFn<NodeType = {}> {
   (alpha: number): void;
-  initialize?: (nodes: NodeObjectIntersection<NodeType>[], ...args: any[]) => void;
+  initialize?: (nodes: NodeObject<NodeType>[], ...args: any[]) => void;
   [key: string]: any;
 }
 
 type Coords = { x: number; y: number; z: number; }
 
-type LinkPositionUpdateFn = <NodeType = {}, LinkType = {}>(obj: Object3D, coords: { start: Coords, end: Coords }, link: LinkObjectIntersection<NodeType, LinkType>) => void | null | boolean;
+type LinkPositionUpdateFn = <NodeType = {}, LinkType = {}>(obj: Object3D, coords: { start: Coords, end: Coords }, link: LinkObject<NodeType, LinkType>) => void | null | boolean;
 
 export interface ForceGraphProps<
   NodeType = {},
   LinkType = {}
 > extends ConfigOptions {
   // Data input
-  graphData?: GraphData<NodeObjectIntersection<NodeType>, LinkObjectIntersection<NodeType, LinkType>>;
+  graphData?: GraphData<NodeObject<NodeType>, LinkObject<NodeType, LinkType>>;
   nodeId?: string;
   linkSource?: string;
   linkTarget?: string;
@@ -62,41 +60,41 @@ export interface ForceGraphProps<
   glScale?: number;
 
   // Node styling
-  nodeLabel?: Accessor<NodeObjectIntersection<NodeType>, string>;
-  nodeDesc?: Accessor<NodeObjectIntersection<NodeType>, string>;
+  nodeLabel?: Accessor<NodeObject<NodeType>, string>;
+  nodeDesc?: Accessor<NodeObject<NodeType>, string>;
   nodeRelSize?: number;
-  nodeVal?: Accessor<NodeObjectIntersection<NodeType>, number>;
-  nodeVisibility?: Accessor<NodeObjectIntersection<NodeType>, boolean>;
-  nodeColor?: Accessor<NodeObjectIntersection<NodeType>, string>;
-  nodeAutoColorBy?: Accessor<NodeObjectIntersection<NodeType>, string | null>;
+  nodeVal?: Accessor<NodeObject<NodeType>, number>;
+  nodeVisibility?: Accessor<NodeObject<NodeType>, boolean>;
+  nodeColor?: Accessor<NodeObject<NodeType>, string>;
+  nodeAutoColorBy?: Accessor<NodeObject<NodeType>, string | null>;
   nodeOpacity?: number;
   nodeResolution?: number;
-  nodeThreeObject?: Accessor<NodeObjectIntersection<NodeType>, Object3D>;
-  nodeThreeObjectExtend?: Accessor<NodeObjectIntersection<NodeType>, boolean>;
+  nodeThreeObject?: Accessor<NodeObject<NodeType>, Object3D>;
+  nodeThreeObjectExtend?: Accessor<NodeObject<NodeType>, boolean>;
 
   // Link styling
-  linkLabel?: Accessor<LinkObjectIntersection<NodeType, LinkType>, string>;
-  linkDesc?: Accessor<LinkObjectIntersection<NodeType, LinkType>, string>;
-  linkVisibility?: Accessor<LinkObjectIntersection<NodeType, LinkType>, boolean>;
-  linkColor?: Accessor<LinkObjectIntersection<NodeType, LinkType>, string>;
-  linkAutoColorBy?: Accessor<LinkObjectIntersection<NodeType, LinkType>, string | null>;
-  linkWidth?: Accessor<LinkObjectIntersection<NodeType, LinkType>, number>;
+  linkLabel?: Accessor<LinkObject<NodeType, LinkType>, string>;
+  linkDesc?: Accessor<LinkObject<NodeType, LinkType>, string>;
+  linkVisibility?: Accessor<LinkObject<NodeType, LinkType>, boolean>;
+  linkColor?: Accessor<LinkObject<NodeType, LinkType>, string>;
+  linkAutoColorBy?: Accessor<LinkObject<NodeType, LinkType>, string | null>;
+  linkWidth?: Accessor<LinkObject<NodeType, LinkType>, number>;
   linkOpacity?: number;
   linkResolution?: number;
-  linkCurvature?: Accessor<LinkObjectIntersection<NodeType, LinkType>, number>;
-  linkCurveRotation?: Accessor<LinkObjectIntersection<NodeType, LinkType>, number>;
-  linkMaterial?: Accessor<LinkObjectIntersection<NodeType, LinkType>, Material | boolean | null>;
-  linkThreeObject?: Accessor<LinkObjectIntersection<NodeType, LinkType>, Object3D>;
-  linkThreeObjectExtend?: Accessor<LinkObjectIntersection<NodeType, LinkType>, boolean>;
+  linkCurvature?: Accessor<LinkObject<NodeType, LinkType>, number>;
+  linkCurveRotation?: Accessor<LinkObject<NodeType, LinkType>, number>;
+  linkMaterial?: Accessor<LinkObject<NodeType, LinkType>, Material | boolean | null>;
+  linkThreeObject?: Accessor<LinkObject<NodeType, LinkType>, Object3D>;
+  linkThreeObjectExtend?: Accessor<LinkObject<NodeType, LinkType>, boolean>;
   linkPositionUpdate?: LinkPositionUpdateFn | null;
-  linkDirectionalArrowLength?: Accessor<LinkObjectIntersection<NodeType, LinkType>, number>;
-  linkDirectionalArrowColor?: Accessor<LinkObjectIntersection<NodeType, LinkType>, string>;
-  linkDirectionalArrowRelPos?: Accessor<LinkObjectIntersection<NodeType, LinkType>, number>;
+  linkDirectionalArrowLength?: Accessor<LinkObject<NodeType, LinkType>, number>;
+  linkDirectionalArrowColor?: Accessor<LinkObject<NodeType, LinkType>, string>;
+  linkDirectionalArrowRelPos?: Accessor<LinkObject<NodeType, LinkType>, number>;
   linkDirectionalArrowResolution?: number;
-  linkDirectionalParticles?: Accessor<LinkObjectIntersection<NodeType, LinkType>, number>;
-  linkDirectionalParticleSpeed?: Accessor<LinkObjectIntersection<NodeType, LinkType>, number>;
-  linkDirectionalParticleWidth?: Accessor<LinkObjectIntersection<NodeType, LinkType>, number>;
-  linkDirectionalParticleColor?: Accessor<LinkObjectIntersection<NodeType, LinkType>, string>;
+  linkDirectionalParticles?: Accessor<LinkObject<NodeType, LinkType>, number>;
+  linkDirectionalParticleSpeed?: Accessor<LinkObject<NodeType, LinkType>, number>;
+  linkDirectionalParticleWidth?: Accessor<LinkObject<NodeType, LinkType>, number>;
+  linkDirectionalParticleColor?: Accessor<LinkObject<NodeType, LinkType>, string>;
   linkDirectionalParticleResolution?: number;
 
   // Force engine (d3-force) configuration
@@ -104,7 +102,7 @@ export interface ForceGraphProps<
   numDimensions?: 1 | 2 | 3;
   dagMode?: DagMode;
   dagLevelDistance?: number | null;
-  dagNodeFilter?: (node: NodeObjectIntersection<NodeType>) => boolean;
+  dagNodeFilter?: (node: NodeObject<NodeType>) => boolean;
   onDagError?: ((loopNodeIds: (string | number)[]) => void) | undefined;
   d3AlphaMin?: number;
   d3AlphaDecay?: number;
@@ -117,10 +115,10 @@ export interface ForceGraphProps<
   onEngineStop?: () => void;
 
   // Interaction
-  onNodeHover?: (node: NodeObjectIntersection<NodeType> | null, previousNode: NodeObjectIntersection<NodeType> | null) => void;
-  onNodeClick?: (link: LinkObjectIntersection<NodeType, LinkType>) => void;
-  onLinkHover?: (link: LinkObjectIntersection<NodeType, LinkType> | null, previousLink: LinkObjectIntersection<NodeType, LinkType> | null) => void;
-  onLinkClick?: (link: LinkObjectIntersection<NodeType, LinkType>) => void;
+  onNodeHover?: (node: NodeObject<NodeType> | null, previousNode: NodeObject<NodeType> | null) => void;
+  onNodeClick?: (link: LinkObject<NodeType, LinkType>) => void;
+  onLinkHover?: (link: LinkObject<NodeType, LinkType> | null, previousLink: LinkObject<NodeType, LinkType> | null) => void;
+  onLinkClick?: (link: LinkObject<NodeType, LinkType>) => void;
 }
 
 export interface ForceGraphMethods<
@@ -128,21 +126,21 @@ export interface ForceGraphMethods<
   LinkType = {}
 > {
   // Link styling
-  emitParticle(link: LinkObjectIntersection<NodeType, LinkType>): ForceGraphKapsuleInstance;
+  emitParticle(link: LinkObject<NodeType, LinkType>): ForceGraphKapsuleInstance;
 
   // Force engine (d3-force) configuration
-  d3Force(forceName: 'link' | 'charge' | 'center' | string): ForceFn<NodeObjectIntersection<NodeType>> | undefined;
-  d3Force(forceName: 'link' | 'charge' | 'center' | string, forceFn: ForceFn<NodeObjectIntersection<NodeType>>): ForceGraphKapsuleInstance;
+  d3Force(forceName: 'link' | 'charge' | 'center' | string): ForceFn<NodeObject<NodeType>> | undefined;
+  d3Force(forceName: 'link' | 'charge' | 'center' | string, forceFn: ForceFn<NodeObject<NodeType>>): ForceGraphKapsuleInstance;
   d3ReheatSimulation(): ForceGraphKapsuleInstance;
 
   // Render control
   refresh(): ForceGraphKapsuleInstance;
 
   // Utility
-  getGraphBbox(nodeFilter?: (node: NodeObjectIntersection<NodeType>) => boolean): { x: [number, number], y: [number, number], z: [number, number] };
+  getGraphBbox(nodeFilter?: (node: NodeObject<NodeType>) => boolean): { x: [number, number], y: [number, number], z: [number, number] };
 }
 
-type FCwithRef = <NodeType = {}, LinkType = {}>(props: ForceGraphProps<NodeObjectIntersection<NodeType>, LinkObjectIntersection<NodeType, LinkType>> & { ref?: React.MutableRefObject<ForceGraphMethods<NodeObjectIntersection<NodeType>, LinkObjectIntersection<NodeType, LinkType>> | undefined>; }) => React.ReactElement;
+type FCwithRef = <NodeType = {}, LinkType = {}>(props: ForceGraphProps<NodeObject<NodeType>, LinkObject<NodeType, LinkType>> & { ref?: React.MutableRefObject<ForceGraphMethods<NodeObject<NodeType>, LinkObject<NodeType, LinkType>> | undefined>; }) => React.ReactElement;
 
 declare const ForceGraph: FCwithRef;
 

--- a/src/packages/react-force-graph-vr/index.d.ts
+++ b/src/packages/react-force-graph-vr/index.d.ts
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { Object3D, Material } from 'three';
 import { ConfigOptions, ForceGraphVRInstance as ForceGraphKapsuleInstance } from '3d-force-graph-vr';
 
-export interface GraphData<NodeType, LinkType> {
+export interface GraphData<NodeType = {}, LinkType = LinkObject<no>> {
   nodes: NodeObjectIntersection<NodeType>[];
   links: LinkObjectIntersection<NodeType, LinkType>[];
 }
@@ -27,7 +27,7 @@ export type LinkObject<NodeType> = {
   target?: string | number | NodeObjectIntersection<NodeType>;
 };
 
-type LinkObjectIntersection<NodeType, LinkType> = LinkType & LinkObject<NodeType>;
+type LinkObjectIntersection<NodeType = {}, LinkType = {}> = LinkType & LinkObject<NodeType>;
 
 type Accessor<In, Out> = Out | string | ((obj: In) => Out);
 
@@ -35,7 +35,7 @@ type DagMode = 'td' | 'bu' | 'lr' | 'rl' | 'zout' | 'zin' | 'radialout' | 'radia
 
 type ForceEngine = 'd3' | 'ngraph';
 
-interface ForceFn<NodeType> {
+interface ForceFn<NodeType = {}> {
   (alpha: number): void;
   initialize?: (nodes: NodeObjectIntersection<NodeType>[], ...args: any[]) => void;
   [key: string]: any;
@@ -43,11 +43,11 @@ interface ForceFn<NodeType> {
 
 type Coords = { x: number; y: number; z: number; }
 
-type LinkPositionUpdateFn = <NodeType, LinkType>(obj: Object3D, coords: { start: Coords, end: Coords }, link: LinkObjectIntersection<NodeType, LinkType>) => void | null | boolean;
+type LinkPositionUpdateFn = <NodeType = {}, LinkType = {}>(obj: Object3D, coords: { start: Coords, end: Coords }, link: LinkObjectIntersection<NodeType, LinkType>) => void | null | boolean;
 
 export interface ForceGraphProps<
-  NodeType,
-  LinkType
+  NodeType = {},
+  LinkType = {}
 > extends ConfigOptions {
   // Data input
   graphData?: GraphData<NodeObjectIntersection<NodeType>, LinkObjectIntersection<NodeType, LinkType>>;
@@ -124,8 +124,8 @@ export interface ForceGraphProps<
 }
 
 export interface ForceGraphMethods<
-  NodeType,
-  LinkType
+  NodeType = {},
+  LinkType = {}
 > {
   // Link styling
   emitParticle(link: LinkObjectIntersection<NodeType, LinkType>): ForceGraphKapsuleInstance;
@@ -142,7 +142,7 @@ export interface ForceGraphMethods<
   getGraphBbox(nodeFilter?: (node: NodeObjectIntersection<NodeType>) => boolean): { x: [number, number], y: [number, number], z: [number, number] };
 }
 
-type FCwithRef = <NodeType, LinkType>(props: ForceGraphProps<NodeObjectIntersection<NodeType>, LinkObjectIntersection<NodeType, LinkType>> & { ref?: React.MutableRefObject<ForceGraphMethods<NodeObjectIntersection<NodeType>, LinkObjectIntersection<NodeType, LinkType>> | undefined>; }) => React.ReactElement;
+type FCwithRef = <NodeType = {}, LinkType = {}>(props: ForceGraphProps<NodeObjectIntersection<NodeType>, LinkObjectIntersection<NodeType, LinkType>> & { ref?: React.MutableRefObject<ForceGraphMethods<NodeObjectIntersection<NodeType>, LinkObjectIntersection<NodeType, LinkType>> | undefined>; }) => React.ReactElement;
 
 declare const ForceGraph: FCwithRef;
 

--- a/src/packages/react-force-graph-vr/index.d.ts
+++ b/src/packages/react-force-graph-vr/index.d.ts
@@ -2,9 +2,9 @@ import * as React from 'react';
 import { Object3D, Material } from 'three';
 import { ConfigOptions, ForceGraphVRInstance as ForceGraphKapsuleInstance } from '3d-force-graph-vr';
 
-export interface GraphData<NodeType extends NodeObject, LinkType extends LinkObject<NodeType>> {
-  nodes: NodeType[];
-  links: LinkType[];
+export interface GraphData<NodeType, LinkType> {
+  nodes: NodeObjectIntersection<NodeType>[];
+  links: LinkObjectIntersection<NodeType, LinkType>[];
 }
 
 export type NodeObject = {
@@ -20,10 +20,14 @@ export type NodeObject = {
   fz?: number;
 };
 
-export type LinkObject<NodeType extends NodeObject> = {
-  source?: string | number | NodeType;
-  target?: string | number | NodeType;
+type NodeObjectIntersection<NodeType> = NodeType & NodeObject;
+
+export type LinkObject<NodeType> = {
+  source?: string | number | NodeObjectIntersection<NodeType>;
+  target?: string | number | NodeObjectIntersection<NodeType>;
 };
+
+type LinkObjectIntersection<NodeType, LinkType> = LinkType & LinkObject<NodeType>;
 
 type Accessor<In, Out> = Out | string | ((obj: In) => Out);
 
@@ -31,22 +35,22 @@ type DagMode = 'td' | 'bu' | 'lr' | 'rl' | 'zout' | 'zin' | 'radialout' | 'radia
 
 type ForceEngine = 'd3' | 'ngraph';
 
-interface ForceFn<NodeType extends NodeObject> {
+interface ForceFn<NodeType> {
   (alpha: number): void;
-  initialize?: (nodes: NodeType[], ...args: any[]) => void;
+  initialize?: (nodes: NodeObjectIntersection<NodeType>[], ...args: any[]) => void;
   [key: string]: any;
 }
 
 type Coords = { x: number; y: number; z: number; }
 
-type LinkPositionUpdateFn = <NodeType extends NodeObject, LinkType extends LinkObject<NodeType>>(obj: Object3D, coords: { start: Coords, end: Coords }, link: LinkType) => void | null | boolean;
+type LinkPositionUpdateFn = <NodeType, LinkType>(obj: Object3D, coords: { start: Coords, end: Coords }, link: LinkObjectIntersection<NodeType, LinkType>) => void | null | boolean;
 
 export interface ForceGraphProps<
-  NodeType extends NodeObject,
-  LinkType extends LinkObject<NodeType>
+  NodeType,
+  LinkType
 > extends ConfigOptions {
   // Data input
-  graphData?: GraphData<NodeType, LinkType>;
+  graphData?: GraphData<NodeObjectIntersection<NodeType>, LinkObjectIntersection<NodeType, LinkType>>;
   nodeId?: string;
   linkSource?: string;
   linkTarget?: string;
@@ -58,41 +62,41 @@ export interface ForceGraphProps<
   glScale?: number;
 
   // Node styling
-  nodeLabel?: Accessor<NodeType, string>;
-  nodeDesc?: Accessor<NodeType, string>;
+  nodeLabel?: Accessor<NodeObjectIntersection<NodeType>, string>;
+  nodeDesc?: Accessor<NodeObjectIntersection<NodeType>, string>;
   nodeRelSize?: number;
-  nodeVal?: Accessor<NodeType, number>;
-  nodeVisibility?: Accessor<NodeType, boolean>;
-  nodeColor?: Accessor<NodeType, string>;
-  nodeAutoColorBy?: Accessor<NodeType, string | null>;
+  nodeVal?: Accessor<NodeObjectIntersection<NodeType>, number>;
+  nodeVisibility?: Accessor<NodeObjectIntersection<NodeType>, boolean>;
+  nodeColor?: Accessor<NodeObjectIntersection<NodeType>, string>;
+  nodeAutoColorBy?: Accessor<NodeObjectIntersection<NodeType>, string | null>;
   nodeOpacity?: number;
   nodeResolution?: number;
-  nodeThreeObject?: Accessor<NodeType, Object3D>;
-  nodeThreeObjectExtend?: Accessor<NodeType, boolean>;
+  nodeThreeObject?: Accessor<NodeObjectIntersection<NodeType>, Object3D>;
+  nodeThreeObjectExtend?: Accessor<NodeObjectIntersection<NodeType>, boolean>;
 
   // Link styling
-  linkLabel?: Accessor<LinkType, string>;
-  linkDesc?: Accessor<LinkType, string>;
-  linkVisibility?: Accessor<LinkType, boolean>;
-  linkColor?: Accessor<LinkType, string>;
-  linkAutoColorBy?: Accessor<LinkType, string | null>;
-  linkWidth?: Accessor<LinkType, number>;
+  linkLabel?: Accessor<LinkObjectIntersection<NodeType, LinkType>, string>;
+  linkDesc?: Accessor<LinkObjectIntersection<NodeType, LinkType>, string>;
+  linkVisibility?: Accessor<LinkObjectIntersection<NodeType, LinkType>, boolean>;
+  linkColor?: Accessor<LinkObjectIntersection<NodeType, LinkType>, string>;
+  linkAutoColorBy?: Accessor<LinkObjectIntersection<NodeType, LinkType>, string | null>;
+  linkWidth?: Accessor<LinkObjectIntersection<NodeType, LinkType>, number>;
   linkOpacity?: number;
   linkResolution?: number;
-  linkCurvature?: Accessor<LinkType, number>;
-  linkCurveRotation?: Accessor<LinkType, number>;
-  linkMaterial?: Accessor<LinkType, Material | boolean | null>;
-  linkThreeObject?: Accessor<LinkType, Object3D>;
-  linkThreeObjectExtend?: Accessor<LinkType, boolean>;
+  linkCurvature?: Accessor<LinkObjectIntersection<NodeType, LinkType>, number>;
+  linkCurveRotation?: Accessor<LinkObjectIntersection<NodeType, LinkType>, number>;
+  linkMaterial?: Accessor<LinkObjectIntersection<NodeType, LinkType>, Material | boolean | null>;
+  linkThreeObject?: Accessor<LinkObjectIntersection<NodeType, LinkType>, Object3D>;
+  linkThreeObjectExtend?: Accessor<LinkObjectIntersection<NodeType, LinkType>, boolean>;
   linkPositionUpdate?: LinkPositionUpdateFn | null;
-  linkDirectionalArrowLength?: Accessor<LinkType, number>;
-  linkDirectionalArrowColor?: Accessor<LinkType, string>;
-  linkDirectionalArrowRelPos?: Accessor<LinkType, number>;
+  linkDirectionalArrowLength?: Accessor<LinkObjectIntersection<NodeType, LinkType>, number>;
+  linkDirectionalArrowColor?: Accessor<LinkObjectIntersection<NodeType, LinkType>, string>;
+  linkDirectionalArrowRelPos?: Accessor<LinkObjectIntersection<NodeType, LinkType>, number>;
   linkDirectionalArrowResolution?: number;
-  linkDirectionalParticles?: Accessor<LinkType, number>;
-  linkDirectionalParticleSpeed?: Accessor<LinkType, number>;
-  linkDirectionalParticleWidth?: Accessor<LinkType, number>;
-  linkDirectionalParticleColor?: Accessor<LinkType, string>;
+  linkDirectionalParticles?: Accessor<LinkObjectIntersection<NodeType, LinkType>, number>;
+  linkDirectionalParticleSpeed?: Accessor<LinkObjectIntersection<NodeType, LinkType>, number>;
+  linkDirectionalParticleWidth?: Accessor<LinkObjectIntersection<NodeType, LinkType>, number>;
+  linkDirectionalParticleColor?: Accessor<LinkObjectIntersection<NodeType, LinkType>, string>;
   linkDirectionalParticleResolution?: number;
 
   // Force engine (d3-force) configuration
@@ -100,7 +104,7 @@ export interface ForceGraphProps<
   numDimensions?: 1 | 2 | 3;
   dagMode?: DagMode;
   dagLevelDistance?: number | null;
-  dagNodeFilter?: (node: NodeType) => boolean;
+  dagNodeFilter?: (node: NodeObjectIntersection<NodeType>) => boolean;
   onDagError?: ((loopNodeIds: (string | number)[]) => void) | undefined;
   d3AlphaMin?: number;
   d3AlphaDecay?: number;
@@ -113,32 +117,32 @@ export interface ForceGraphProps<
   onEngineStop?: () => void;
 
   // Interaction
-  onNodeHover?: (node: NodeType | null, previousNode: NodeType | null) => void;
-  onNodeClick?: (link: LinkType) => void;
-  onLinkHover?: (link: LinkType | null, previousLink: LinkType | null) => void;
-  onLinkClick?: (link: LinkType) => void;
+  onNodeHover?: (node: NodeObjectIntersection<NodeType> | null, previousNode: NodeObjectIntersection<NodeType> | null) => void;
+  onNodeClick?: (link: LinkObjectIntersection<NodeType, LinkType>) => void;
+  onLinkHover?: (link: LinkObjectIntersection<NodeType, LinkType> | null, previousLink: LinkObjectIntersection<NodeType, LinkType> | null) => void;
+  onLinkClick?: (link: LinkObjectIntersection<NodeType, LinkType>) => void;
 }
 
 export interface ForceGraphMethods<
-  NodeType extends NodeObject,
-  LinkType extends LinkObject<NodeType>
+  NodeType,
+  LinkType
 > {
   // Link styling
-  emitParticle(link: LinkType): ForceGraphKapsuleInstance;
+  emitParticle(link: LinkObjectIntersection<NodeType, LinkType>): ForceGraphKapsuleInstance;
 
   // Force engine (d3-force) configuration
-  d3Force(forceName: 'link' | 'charge' | 'center' | string): ForceFn<NodeType> | undefined;
-  d3Force(forceName: 'link' | 'charge' | 'center' | string, forceFn: ForceFn<NodeType>): ForceGraphKapsuleInstance;
+  d3Force(forceName: 'link' | 'charge' | 'center' | string): ForceFn<NodeObjectIntersection<NodeType>> | undefined;
+  d3Force(forceName: 'link' | 'charge' | 'center' | string, forceFn: ForceFn<NodeObjectIntersection<NodeType>>): ForceGraphKapsuleInstance;
   d3ReheatSimulation(): ForceGraphKapsuleInstance;
 
   // Render control
   refresh(): ForceGraphKapsuleInstance;
 
   // Utility
-  getGraphBbox(nodeFilter?: (node: NodeType) => boolean): { x: [number, number], y: [number, number], z: [number, number] };
+  getGraphBbox(nodeFilter?: (node: NodeObjectIntersection<NodeType>) => boolean): { x: [number, number], y: [number, number], z: [number, number] };
 }
 
-type FCwithRef = <NodeType extends NodeObject, LinkType extends LinkObject<NodeType>>(props: ForceGraphProps<NodeType, LinkType> & { ref?: React.MutableRefObject<ForceGraphMethods<NodeType, LinkType> | undefined>; }) => React.ReactElement;
+type FCwithRef = <NodeType, LinkType>(props: ForceGraphProps<NodeObjectIntersection<NodeType>, LinkObjectIntersection<NodeType, LinkType>> & { ref?: React.MutableRefObject<ForceGraphMethods<NodeObjectIntersection<NodeType>, LinkObjectIntersection<NodeType, LinkType>> | undefined>; }) => React.ReactElement;
 
 declare const ForceGraph: FCwithRef;
 

--- a/src/packages/react-force-graph-vr/index.d.ts
+++ b/src/packages/react-force-graph-vr/index.d.ts
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { Object3D, Material } from 'three';
 import { ConfigOptions, ForceGraphVRInstance as ForceGraphKapsuleInstance } from '3d-force-graph-vr';
 
-export interface GraphData<NodeType = {}, LinkType = LinkObject<no>> {
+export interface GraphData<NodeType = {}, LinkType = {}> {
   nodes: NodeObjectIntersection<NodeType>[];
   links: LinkObjectIntersection<NodeType, LinkType>[];
 }

--- a/src/packages/react-force-graph-vr/index.d.ts
+++ b/src/packages/react-force-graph-vr/index.d.ts
@@ -28,6 +28,8 @@ export type LinkObject<NodeType = {}, LinkType = {}> = LinkType & {
 };
 
 type Accessor<In, Out> = Out | string | ((obj: In) => Out);
+type NodeAccessor<NodeType, T> = Accessor<NodeObject<NodeType>, T>;
+type LinkAccessor<NodeType, LinkType, T> = Accessor<LinkObject<NodeType, LinkType>, T>;
 
 type DagMode = 'td' | 'bu' | 'lr' | 'rl' | 'zout' | 'zin' | 'radialout' | 'radialin';
 
@@ -60,41 +62,41 @@ export interface ForceGraphProps<
   glScale?: number;
 
   // Node styling
-  nodeLabel?: Accessor<NodeObject<NodeType>, string>;
-  nodeDesc?: Accessor<NodeObject<NodeType>, string>;
+  nodeLabel?: NodeAccessor<NodeType, string>;
+  nodeDesc?: NodeAccessor<NodeType, string>;
   nodeRelSize?: number;
-  nodeVal?: Accessor<NodeObject<NodeType>, number>;
-  nodeVisibility?: Accessor<NodeObject<NodeType>, boolean>;
-  nodeColor?: Accessor<NodeObject<NodeType>, string>;
-  nodeAutoColorBy?: Accessor<NodeObject<NodeType>, string | null>;
+  nodeVal?: NodeAccessor<NodeType, number>;
+  nodeVisibility?: NodeAccessor<NodeType, boolean>;
+  nodeColor?: NodeAccessor<NodeType, string>;
+  nodeAutoColorBy?: NodeAccessor<NodeType, string | null>;
   nodeOpacity?: number;
   nodeResolution?: number;
-  nodeThreeObject?: Accessor<NodeObject<NodeType>, Object3D>;
-  nodeThreeObjectExtend?: Accessor<NodeObject<NodeType>, boolean>;
+  nodeThreeObject?: NodeAccessor<NodeType, Object3D>;
+  nodeThreeObjectExtend?: NodeAccessor<NodeType, boolean>;
 
   // Link styling
-  linkLabel?: Accessor<LinkObject<NodeType, LinkType>, string>;
-  linkDesc?: Accessor<LinkObject<NodeType, LinkType>, string>;
-  linkVisibility?: Accessor<LinkObject<NodeType, LinkType>, boolean>;
-  linkColor?: Accessor<LinkObject<NodeType, LinkType>, string>;
-  linkAutoColorBy?: Accessor<LinkObject<NodeType, LinkType>, string | null>;
-  linkWidth?: Accessor<LinkObject<NodeType, LinkType>, number>;
+  linkLabel?: LinkAccessor<NodeType, LinkType, string>;
+  linkDesc?: LinkAccessor<NodeType, LinkType, string>;
+  linkVisibility?: LinkAccessor<NodeType, LinkType, boolean>;
+  linkColor?: LinkAccessor<NodeType, LinkType, string>;
+  linkAutoColorBy?: LinkAccessor<NodeType, LinkType, string | null>;
+  linkWidth?: LinkAccessor<NodeType, LinkType, number>;
   linkOpacity?: number;
   linkResolution?: number;
-  linkCurvature?: Accessor<LinkObject<NodeType, LinkType>, number>;
-  linkCurveRotation?: Accessor<LinkObject<NodeType, LinkType>, number>;
-  linkMaterial?: Accessor<LinkObject<NodeType, LinkType>, Material | boolean | null>;
-  linkThreeObject?: Accessor<LinkObject<NodeType, LinkType>, Object3D>;
-  linkThreeObjectExtend?: Accessor<LinkObject<NodeType, LinkType>, boolean>;
+  linkCurvature?: LinkAccessor<NodeType, LinkType, number>;
+  linkCurveRotation?: LinkAccessor<NodeType, LinkType, number>;
+  linkMaterial?: LinkAccessor<NodeType, LinkType, Material | boolean | null>;
+  linkThreeObject?: LinkAccessor<NodeType, LinkType, Object3D>;
+  linkThreeObjectExtend?: LinkAccessor<NodeType, LinkType, boolean>;
   linkPositionUpdate?: LinkPositionUpdateFn | null;
-  linkDirectionalArrowLength?: Accessor<LinkObject<NodeType, LinkType>, number>;
-  linkDirectionalArrowColor?: Accessor<LinkObject<NodeType, LinkType>, string>;
-  linkDirectionalArrowRelPos?: Accessor<LinkObject<NodeType, LinkType>, number>;
+  linkDirectionalArrowLength?: LinkAccessor<NodeType, LinkType, number>;
+  linkDirectionalArrowColor?: LinkAccessor<NodeType, LinkType, string>;
+  linkDirectionalArrowRelPos?: LinkAccessor<NodeType, LinkType, number>;
   linkDirectionalArrowResolution?: number;
-  linkDirectionalParticles?: Accessor<LinkObject<NodeType, LinkType>, number>;
-  linkDirectionalParticleSpeed?: Accessor<LinkObject<NodeType, LinkType>, number>;
-  linkDirectionalParticleWidth?: Accessor<LinkObject<NodeType, LinkType>, number>;
-  linkDirectionalParticleColor?: Accessor<LinkObject<NodeType, LinkType>, string>;
+  linkDirectionalParticles?: LinkAccessor<NodeType, LinkType, number>;
+  linkDirectionalParticleSpeed?: LinkAccessor<NodeType, LinkType, number>;
+  linkDirectionalParticleWidth?: LinkAccessor<NodeType, LinkType, number>;
+  linkDirectionalParticleColor?: LinkAccessor<NodeType, LinkType, string>;
   linkDirectionalParticleResolution?: number;
 
   // Force engine (d3-force) configuration

--- a/src/packages/react-force-graph-vr/index.d.ts
+++ b/src/packages/react-force-graph-vr/index.d.ts
@@ -20,14 +20,14 @@ export type NodeObject = {
   fz?: number;
 };
 
-type NodeObjectIntersection<NodeType> = NodeType & NodeObject;
+type NodeObjectIntersection<NodeType> = NodeType & NodeObject & { [others: string]: any; };
 
 export type LinkObject<NodeType> = {
   source?: string | number | NodeObjectIntersection<NodeType>;
   target?: string | number | NodeObjectIntersection<NodeType>;
 };
 
-type LinkObjectIntersection<NodeType = {}, LinkType = {}> = LinkType & LinkObject<NodeType>;
+type LinkObjectIntersection<NodeType = {}, LinkType = {}> = LinkType & LinkObject<NodeType> & { [others: string]: any; };
 
 type Accessor<In, Out> = Out | string | ((obj: In) => Out);
 


### PR DESCRIPTION
Fixes #196 


This pull request adds the functionality to automatically infer the data format passed to the `ForceGraph` component with the use of TypeScript generics so that all `ForceGraph` functions/properties will automatically know the node and link data format.